### PR TITLE
Github workflow + refactoring of security index initialisation  

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - edge
-      - ci_cd-pipeline
 
 jobs:
   build:
@@ -20,7 +19,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          ref: ci_cd-pipeline
+          ref: edge
 
       - id: build-snap
         name: Build snap

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -22,14 +22,6 @@ jobs:
         with:
           ref: ci_cd-pipeline
 
-      - name: List checked out files
-        run: |
-          pwd
-          ls -la
-          echo "--- github.workspace ----"
-          ls -la ${{github.workspace}}
-          
-
       - id: build-snap
         name: Build snap
         uses: snapcore/action-build@v1

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: opensearch_snap_amd64
-          path: ./
+          path: .
 
       - name: Install snap file
         run: |
@@ -109,7 +109,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: opensearch_snap_amd64
-          path: ./
+          path: .
 
       - name: Publish snap to Store
         uses: snapcore/action-publish@v1

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,125 @@
+name: Build OpenSearch from source and run tests
+
+env:
+  VERSION: 2.2.1
+  RELEASE: edge
+
+on:
+  push:
+    branches:
+      - edge
+
+jobs:
+  build:
+    name: Build Snap
+    runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: edge
+
+      - id: build-snap
+        name: Build snap
+        uses: snapcore/action-build@v1
+        with:
+          snapcraft-channel: 7.x/candidate
+
+      - name: Upload built snap job artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: opensearch_snap_amd64
+          path: opensearch_${{env.VERSION}}_amd64.snap
+
+  test:
+    name: Test Snap
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download snap file
+        uses: actions/download-artifact@v3
+        with:
+          name: opensearch_snap_amd64
+          path: ./
+
+      - name: Install snap file
+        run: |
+          sudo snap install opensearch_${{env.VERSION}}_amd64.snap --dangerous
+
+      - name: Setup and Start OpenSearch
+        run: |
+          # connect interfaces
+          sudo snap connect opensearch:log-observe
+          sudo snap connect opensearch:mount-observe
+          sudo snap connect opensearch:process-control
+          sudo snap connect opensearch:procsys-read
+          sudo snap connect opensearch:procsys-write
+          sudo snap connect opensearch:system-observe
+          
+          # create the certificates
+          sudo snap run opensearch.setup \
+              --node-name cm0 \
+              --node-roles cluster_manager,data \
+              --tls-root-password root1234 \
+              --tls-admin-password admin1234 \
+              --tls-node-password node1234 \
+              --tls-init-setup yes                 # this creates the root and admin certs as well.
+          
+          # set the admin password
+          sudo snap set opensearch admin-password=admin1234
+          sudo snap set opensearch init-security=yes
+          
+          # system configs required by opensearch, can set one of the following ways:
+          sysctl -w vm.max_map_count=262144
+          
+          # start opensearch
+          sudo snap start opensearch.daemon
+          
+          # wait a bit for it to fully initialize
+          sleep 30s
+          
+          # create the security index
+          sudo snap run opensearch.security-init
+
+      - name: Ensure the cluster is reachable and node created
+        run: |
+          sudo snap install yq
+          
+          # Check node name
+          cluster_resp=$(curl -k -XGET https://localhost:9200 -u 'admin:admin')
+          echo -e "Cluster Response: \n ${cluster_resp}"
+          node_name=$(echo "${cluster_resp}" | yq -r .name)
+          if [ "${node_name}" != "cm0" ]; then
+              exit 1
+          fi
+          
+          # Check cluster health
+          health_resp=$(curl -k -XGET https://localhost:9200/_cluster/health -u 'admin:admin')
+          echo -e "Cluster Health Response: \n ${health_resp}"
+          cluster_status=$(echo "${health_resp}" | yq -r .status)
+          if [ "${cluster_status}" != "green" ]; then
+              exit 1
+          fi
+
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    steps:
+      - name: Download snap file
+        uses: actions/download-artifact@v3
+        with:
+          name: opensearch_snap_amd64
+          path: ./
+
+      - name: Publish snap to Store
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: opensearch_${{env.VERSION}}_amd64.snap
+          release: ${{env.RELEASE}}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          ref: edge
+          ref: ci_cd-pipeline
 
       - name: List checked out files
         run: |
@@ -35,7 +35,6 @@ jobs:
         uses: snapcore/action-build@v1
         with:
           snapcraft-channel: 7.x/candidate
-          path: ${{github.workspace}}
 
       - name: Upload built snap job artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - edge
+      - ci_cd-pipeline
 
 jobs:
   build:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -22,12 +22,20 @@ jobs:
         with:
           ref: edge
 
+      - name: List checked out files
+        run: |
+          pwd
+          ls -la
+          echo "--- github.workspace ----"
+          ls -la ${{github.workspace}}
+          
+
       - id: build-snap
         name: Build snap
         uses: snapcore/action-build@v1
         with:
           snapcraft-channel: 7.x/candidate
-          path: ${{ github.workspace }}
+          path: ${{github.workspace}}
 
       - name: Upload built snap job artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: snapcore/action-build@v1
         with:
           snapcraft-channel: 7.x/candidate
+          path: ${{ github.workspace }}
 
       - name: Upload built snap job artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -56,7 +56,6 @@ jobs:
           sudo snap connect opensearch:mount-observe
           sudo snap connect opensearch:process-control
           sudo snap connect opensearch:procsys-read
-          sudo snap connect opensearch:procsys-write
           sudo snap connect opensearch:system-observe
           
           # create the certificates
@@ -68,10 +67,6 @@ jobs:
               --tls-node-password node1234 \
               --tls-init-setup yes                 # this creates the root and admin certs as well.
           
-          # set the admin password
-          sudo snap set opensearch admin-password=admin1234
-          sudo snap set opensearch init-security=yes
-          
           # system configs required by opensearch, can set one of the following ways:
           sysctl -w vm.max_map_count=262144
           
@@ -79,10 +74,10 @@ jobs:
           sudo snap start opensearch.daemon
           
           # wait a bit for it to fully initialize
-          sleep 30s
+          sleep 5s
           
           # create the security index
-          sudo snap run opensearch.security-init
+          sudo snap run opensearch.security-init --admin-password=admin1234
 
       - name: Ensure the cluster is reachable and node created
         run: |

--- a/CONTRIBUTOR.md
+++ b/CONTRIBUTOR.md
@@ -15,33 +15,26 @@ sudo snap connect opensearch:log-observe
 sudo snap connect opensearch:mount-observe
 sudo snap connect opensearch:process-control
 sudo snap connect opensearch:procsys-read
-sudo snap connect opensearch:procsys-write
 sudo snap connect opensearch:system-observe
 
 # create the certificates
 sudo snap run opensearch.setup \
-    --node-name master0 \
+    --node-name cm0 \
     --node-roles cluster_manager,data \
     --tls-root-password root1234 \
     --tls-admin-password admin1234 \
     --tls-node-password node1234 \
     --tls-init-setup yes                 # this creates the root and admin certs as well.
 
-# set the admin password
-sudo snap set opensearch admin-password=admin1234
-
-# only in the first cluster setup, or for rebuilding the security index
-sudo snap set opensearch init-security=yes
-
-# system configs required by opensearch, can set one of the following ways:
-    # 1- by users in local machines, adjust values if needed
-        sysctl -w vm.swappiness=0
-        sysctl -w vm.max_map_count=262144
-        sysctl -w net.ipv4.tcp_retries2=5
-        
-    # 2- by juju or cloud deployments:
-        sudo snap set set-sysctl-props=yes
+# system configs required by opensearch, should be set using the following way:
+sysctl -w vm.swappiness=0
+sysctl -w vm.max_map_count=262144
+sysctl -w net.ipv4.tcp_retries2=5
 
 # start opensearch
 sudo snap start opensearch.daemon
+
+# initialize the security index
+# should only be called once per cluster, or for rebuilding the security index
+sudo snap run opensearch.security-init --admin-password=admin1234
 ```

--- a/scripts/wrappers/security-init.sh
+++ b/scripts/wrappers/security-init.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -eux
+
+
+usage() {
+cat << EOF
+usage: start.sh --init-security yes --admin-password ...
+To be ran / setup once per cluster - or when wanting to rebuild the security index.
+--admin-password  (Optional)    Passphrase of the admin key
+--help                          Shows help menu
+EOF
+}
+
+
+# Args
+admin_password=""
+
+
+# Args handling
+function parse_args () {
+    # init-security boolean - from the charm, this should be based on a flag on the app data bag.
+    local LONG_OPTS_LIST=(
+        "admin-password"
+        "help"
+    )
+    local opts=$(getopt \
+      --longoptions "$(printf "%s:," "${LONG_OPTS_LIST[@]}")" \
+      --name "$(readlink -f "${BASH_SOURCE}")" \
+      --options "" \
+      -- "$@"
+    )
+    eval set -- "${opts}"
+
+    while [ $# -gt 0 ]; do
+        case $1 in
+            --admin-password) shift
+                admin_password=$1
+                ;;
+            --help) usage
+                exit
+                ;;
+        esac
+        shift
+    done
+
+    # in case those are set through snap.set
+    # init_security="$(snapctl get init-security)"
+    # admin_password="$(snapctl get admin-password)"
+}
+
+function init_security_plugin () {
+    sec_args=(
+        "-cd" "${OPENSEARCH_PATH_CONF}/opensearch-security/"
+        "-icl" "-nhnv"
+        "-cacert" "${OPENSEARCH_PATH_CERTS}/root-ca.pem"
+        "-cert" "${OPENSEARCH_PATH_CERTS}/admin.pem"
+        "-key" "${OPENSEARCH_PATH_CERTS}/admin-key.pem"
+    )
+
+    if [ -n "${admin_password}" ]; then
+        sec_args+=("-keypass" "${admin_password}")
+    fi
+
+    source \
+        "${OPENSEARCH_PLUGINS}/opensearch-security/tools/securityadmin.sh" \
+        "${sec_args[@]}"
+}
+
+
+parse_args "$@"
+
+# give it some time to bootstrap in case the commands were chained
+# replace later with a request to the opensearch rest api
+# and test on "OpenSearch Security not initialized." output
+sleep 10s
+
+source "${OPS_ROOT}"/helpers/snap-logger.sh "security-config"
+init_security_plugin

--- a/scripts/wrappers/setup.sh
+++ b/scripts/wrappers/setup.sh
@@ -4,6 +4,8 @@ set -eux
 
 source "${OPS_ROOT}"/helpers/snap-logger.sh "setup"
 source "${OPS_ROOT}"/helpers/set-conf.sh
+source "${OPS_ROOT}"/helpers/io.sh
+
 
 usage() {
 cat << EOF
@@ -173,10 +175,6 @@ function set_defaults () {
     if [ -z "${tls_for_rest}" ] || [ "${tls_for_rest}" != "no" ]; then
         tls_for_rest="yes"
     fi
-
-
-
-    # [discovery.seed_hosts, discovery.seed_providers, cluster.initial_cluster_manager_nodes / cluster.initial_master_nodes]
 }
 
 
@@ -234,6 +232,11 @@ if [ "${tls_self_managed}" ]; then
                 --admin-subject "${tls_admin_subject}" \
                 --rest-with-tls "${tls_for_rest}" \
                 --target-dir "${OPENSEARCH_PATH_CERTS}"
+
+        keys=("root-ca" "root-ca-key" "admin" "admin-key")
+        for key in "${keys[@]}"; do
+            set_access_restrictions "${OPENSEARCH_PATH_CERTS}/${key}.pem" 660
+        done
     fi
 
     # create node cert
@@ -245,8 +248,9 @@ if [ "${tls_self_managed}" ]; then
             --node-subject "${tls_node_subject}" \
             --rest-with-tls "${tls_for_rest}" \
             --target-dir "${OPENSEARCH_PATH_CERTS}"
+
+    keys=("node-${node_name}" "node-${node_name}-key")
+    for key in "${keys[@]}"; do
+        set_access_restrictions "${OPENSEARCH_PATH_CERTS}/${key}.pem" 660
+    done
 fi
-
-chown -R snap_daemon "${OPENSEARCH_PATH_CERTS}"
-chgrp root "${OPENSEARCH_PATH_CERTS}"
-

--- a/scripts/wrappers/start.sh
+++ b/scripts/wrappers/start.sh
@@ -3,7 +3,7 @@
 set -eux
 
 
-source "${OPS_ROOT}"/helpers/snap-logger.sh "daemon"
+# source "${OPS_ROOT}"/helpers/snap-logger.sh "daemon"
 source "${OPS_ROOT}"/helpers/snap-interfaces.sh
 source "${OPS_ROOT}"/sys/set-sys-config.sh
 
@@ -40,35 +40,16 @@ function set_defaults () {
 function start_opensearch () {
     exit_if_missing_perm "log-observe"
     exit_if_missing_perm "mount-observe"
+    exit_if_missing_perm "process-control"
     exit_if_missing_perm "procsys-read"
+    exit_if_missing_perm "system-observe"
 
     # start
     "${SNAP}"/usr/bin/setpriv \
         --clear-groups \
         --reuid snap_daemon \
         --regid snap_daemon -- \
-        "${OPENSEARCH_HOME}"/bin/opensearch &
-
-    # give it some time to bootstrap
-    sleep 30s
-}
-
-function init_security_plugin () {
-    sec_args=(
-        "-cd" "${OPENSEARCH_PATH_CONF}/opensearch-security/"
-        "-icl" "-nhnv"
-        "-cacert" "${OPENSEARCH_PATH_CERTS}/root-ca.pem"
-        "-cert" "${OPENSEARCH_PATH_CERTS}/admin.pem"
-        "-key" "${OPENSEARCH_PATH_CERTS}/admin-key.pem"
-    )
-
-    if [ -n "${admin_password}" ]; then
-        sec_args+=("-keypass" "${admin_password}")
-    fi
-
-    source \
-        "${OPENSEARCH_PLUGINS}/opensearch-security/tools/securityadmin.sh" \
-        "${sec_args[@]}"
+        "${OPENSEARCH_HOME}"/bin/opensearch
 }
 
 
@@ -76,7 +57,3 @@ parse_args
 set_defaults
 
 start_opensearch
-
-if [ "${init_security}" == "yes" ]; then
-    init_security_plugin
-fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
 
-version: '2.2.0' # just for humans, typically '1.2+git' or '1.3.2'
+version: '2.2.1' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |
@@ -79,11 +79,6 @@ plugs:
       - /sys/fs/cgroup/system.slice/snap.opensearch.daemon.service/pids.events
       - /sys/fs/cgroup/system.slice/snap.opensearch.daemon.service/pids.max
 
-  procsys-write:
-    interface: system-files
-    write:
-      - /proc/self/coredump_filter
-
 hooks:
   install:
     plugs:
@@ -106,13 +101,12 @@ environment:
   OPENSEARCH_TMPDIR: ${SNAP_COMMON}/tmp
   OPENSEARCH_PLUGINS: ${SNAP_DATA}/plugins
 
-
 apps:
   daemon:
     daemon: simple
     install-mode: disable
     command: ops/start.sh
-    reload-command: ops/start.sh
+    # reload-command: ops/start.sh
     plugs:
       - network
       - network-bind
@@ -124,6 +118,17 @@ apps:
       - system-observe
     environment:
       OPS_ROOT: ${SNAP}/ops
+      OPENSEARCH_PATH_CERTS: ${OPENSEARCH_PATH_CONF}/certificates
+
+  security-init:
+    command: ops/security-config.sh
+    plugs:
+      - network
+      - network-bind
+    environment:
+      OPS_ROOT: ${SNAP}/ops
+      OPENSEARCH_PATH_CERTS: ${OPENSEARCH_PATH_CONF}/certificates
+      JAVA_OPTS: ""
 
   setup:
     command: ops/setup.sh
@@ -141,12 +146,6 @@ apps:
     command: ops/plugins/remove.sh
 
 parts:
-#  python-requirements:
-#    plugin: python
-#    source: ./scripts
-#    python-packages:
-#      - ruamel.yaml
-
   dependencies:
     plugin: nil
     stage-snaps:
@@ -185,8 +184,7 @@ parts:
     plugin: nil
     override-build: |
         version="$(craftctl get version)"
-        echo $version
-        archive_name="opensearch-${version}-linux.tar.gz"
+        archive="opensearch-${version}-linux-x64.tar.gz"
       
-        curl -o "${archive_name}" https://opensearch-builds.s3.eu-west-1.amazonaws.com/core/"${archive_name}"
-        tar -xzvf "${archive_name}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
+        curl -o "${archive}" "https://artifacts.opensearch.org/releases/bundle/opensearch/${version}/${archive}"
+        tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -121,7 +121,7 @@ apps:
       OPENSEARCH_PATH_CERTS: ${OPENSEARCH_PATH_CONF}/certificates
 
   security-init:
-    command: ops/security-config.sh
+    command: ops/security-init.sh
     plugs:
       - network
       - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -114,7 +114,6 @@ apps:
       - mount-observe
       - process-control
       - procsys-read
-      - procsys-write
       - system-observe
     environment:
       OPS_ROOT: ${SNAP}/ops


### PR DESCRIPTION
This PR contains:
- A github workflow with tests and publish to the snapcraft store
- A separate app for initializing the security index, allowing users to optionally / consciously run this app if needed
- Fix of some permissions and access 
- Removal of s3 reference and usage of Opensearch's own distributed tarballs (while security provides us with ours) 
- Bumped version of Opensearch to `2.2.1`
- Readme update