### PR TITLE
Make process-control optional

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -7,7 +7,7 @@ env:
 on:
   push:
     branches:
-      - edge
+      - main
 
 jobs:
   build:
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-        with:
-          ref: edge
 
       - id: build-snap
         name: Build snap

--- a/scripts/wrappers/start.sh
+++ b/scripts/wrappers/start.sh
@@ -40,7 +40,6 @@ function set_defaults () {
 function start_opensearch () {
     exit_if_missing_perm "log-observe"
     exit_if_missing_perm "mount-observe"
-    exit_if_missing_perm "process-control"
     exit_if_missing_perm "sys-fs-cgroup-service"
     exit_if_missing_perm "system-observe"
 

--- a/scripts/wrappers/sys/set-sys-config.sh
+++ b/scripts/wrappers/sys/set-sys-config.sh
@@ -22,7 +22,6 @@ function set_defaults () {
 }
 
 function set_ulimits () {
-    exit_if_missing_perm "process-control"
     exit_if_missing_perm "sys-fs-cgroup-service"
 
     # 1. Set the number of open file handles
@@ -39,7 +38,9 @@ function set_ulimits () {
 
     # 3. Set the locked-in memory size to unlimited
     # ulimit -l 1964328 -- default in local machine
-    ulimit -l unlimited
+    if snapctl is-connected "process-control"; then
+        ulimit -l unlimited
+    fi
 }
 
 


### PR DESCRIPTION
This is a very small PR, that makes the interface `process-control` optional.