### PR TITLE
Removed the edge branch from the workflow

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - edge
       - track/**
       - feature/**
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - edge
 
 jobs:
   build-run-tests:


### PR DESCRIPTION
This PR is about removing the old `edge` branch from the ci / cd workflow.