### PR TITLE
Renamed job name on release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
       - main
 
 jobs:
-  build-run-tests:
+  ci-tests:
     name: Build and Run Tests
     uses: ./.github/workflows/ci.yaml
 


### PR DESCRIPTION
This is a very minor PR to attempt a fix on a job not being called on the release pipeline.