### PR TITLE
Added linux packages upgrade on CI and bumped OpenSearch version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 env:
-  VERSION: 2.4.0
+  VERSION: 2.4.1
 
 on:
   workflow_call:
@@ -18,6 +18,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Upgrade linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get upgrade --yes
 
       - id: build-snap
         name: Build snap

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Build OpenSearch from source, run tests and release.
 
 env:
-  VERSION: 2.4.0
+  VERSION: 2.4.1
   RELEASE: edge
 
 on:

--- a/CONTRIBUTOR.md
+++ b/CONTRIBUTOR.md
@@ -8,7 +8,7 @@ Steps to install it locally:
 snapcraft --debug
 
 # install the snap
-sudo snap install opensearch_2.4.0_amd64.snap --dangerous --jailmode
+sudo snap install opensearch_2.4.1_amd64.snap --dangerous --jailmode
 ```
 
 ### Environment configuration:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ analytics suite that makes it easy to ingest, search, visualize, and analyze dat
 
 ### Installation:
 ```
-sudo snap install opensearch --channel=2.4.0/edge
+sudo snap install opensearch --channel=2.4.1/edge
 sudo snap connect opensearch:process-control
 ```
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
 
-version: '2.4.0' # just for humans, typically '1.2+git' or '1.3.2'
+version: '2.4.1' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |


### PR DESCRIPTION
This PR contains:
- upgrade of linux packages on the github actions (we got a security alert regarding outdated packages)
- bump of OpenSearch version to `2.4.1`