### PR TITLE
Bumped version of opensearch to 2.5.0 + removed archive after extracting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 env:
-  VERSION: 2.4.1
+  VERSION: 2.5.0
 
 on:
   workflow_call:
@@ -22,7 +22,15 @@ jobs:
       - name: Upgrade linux deps
         run: |
           sudo apt-get update
-          sudo apt-get upgrade --yes
+          
+          # install security updates
+          sudo apt-get -s dist-upgrade \
+            | grep "^Inst" \
+            | grep -i securi \
+            | awk -F " " {'print $2'} \
+            | xargs sudo apt-get install -y
+          
+          sudo apt-get autoremove -y
 
       - id: build-snap
         name: Build snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
 
-version: '2.4.1' # just for humans, typically '1.2+git' or '1.3.2'
+version: '2.5.0' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |
@@ -160,3 +160,5 @@ parts:
       
         curl -o "${archive}" "https://artifacts.opensearch.org/releases/bundle/opensearch/${version}/${archive}"
         tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
+      
+        rm "${archive}"


### PR DESCRIPTION
This PR does the following:
- Bumped OpenSearch version to `2.5.0`
- Removed opensearch archive after extracting it
- Limited the dependency upgrades to the security ones 