### PR TITLE
Added restart rules for the opensearch service

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,8 @@ apps:
     daemon: simple
     install-mode: disable
     command: ops/start.sh
+    restart-condition: always
+    restart-delay: 20s
     # reload-command: ops/start.sh
     plugs:
       - network


### PR DESCRIPTION
This PR adds a restart logic to the opensearch service, always restarts with a waiting time of 20sec.