### PR TITLE
[DPE-2121] Added support for performance analyzer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,10 +38,7 @@ jobs:
           
           sudo apt-get autoremove -y
           sudo apt-get clean -y
-          
-          sudo snap info snapd
           sudo snap refresh snapd
-          sudo snap info snapd
 
       - id: build-snap
         name: Build snap
@@ -66,6 +63,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Upgrade snapd
+        run: |
+          sudo snap refresh snapd
 
       - name: Download snap file
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Upgrade linux deps
         run: |
           sudo apt-get update
+          sudo apt-get upgrade -y
           
           # install security updates
           sudo apt-get -s dist-upgrade \
@@ -37,6 +38,9 @@ jobs:
             | xargs sudo apt-get install -y
           
           sudo apt-get autoremove -y
+          sudo apt-get clean -y
+          
+          sudo snap info snapd
 
       - id: build-snap
         name: Build snap

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,7 @@ jobs:
           sudo snap connect opensearch:process-control
           sudo snap connect opensearch:system-observe
           sudo snap connect opensearch:sys-fs-cgroup-service
+          sudo snap connect opensearch:shmem-perf-analyzer
 
       - name: Setup and Start OpenSearch
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,6 @@ jobs:
       - name: Upgrade linux deps
         run: |
           sudo apt-get update
-          sudo apt-get upgrade -y
           
           # install security updates
           sudo apt-get -s dist-upgrade \
@@ -40,6 +39,8 @@ jobs:
           sudo apt-get autoremove -y
           sudo apt-get clean -y
           
+          sudo snap info snapd
+          sudo snap refresh snapd
           sudo snap info snapd
 
       - id: build-snap

--- a/CONTRIBUTOR.md
+++ b/CONTRIBUTOR.md
@@ -8,7 +8,7 @@ Steps to install it locally:
 snapcraft --debug
 
 # install the snap
-sudo snap install opensearch_2.8.0_amd64.snap --dangerous --jailmode
+sudo snap install opensearch_2.9.0_amd64.snap --dangerous --jailmode
 ```
 
 ### Environment configuration:

--- a/scripts/helpers/io.sh
+++ b/scripts/helpers/io.sh
@@ -23,7 +23,7 @@ function add_file () {
 }
 
 function dir_copy_if_not_exists () {
-    cp -R -n -r -p "${SNAP}/${1}" "${2}"
+    cp -R -n -r "${SNAP}/${1}" "${2}"
 
     if [[ $# -eq 3 ]]; then
         set_access_restrictions "${2}/${1}" "${3}"
@@ -33,7 +33,7 @@ function dir_copy_if_not_exists () {
 }
 
 function file_copy () {
-    cp -n -p "${SNAP}/${1}" "${2}"
+    cp -n "${SNAP}/${1}" "${2}"
 
     if [[ $# -eq 3 ]]; then
         set_access_restrictions "${2}/${1}" "${3}"

--- a/scripts/helpers/io.sh
+++ b/scripts/helpers/io.sh
@@ -23,7 +23,7 @@ function add_file () {
 }
 
 function dir_copy_if_not_exists () {
-    cp -R -n -r "${SNAP}/${1}" "${2}"
+    cp -R -n "${SNAP}/${1}" "${2}"
 
     if [[ $# -eq 3 ]]; then
         set_access_restrictions "${2}/${1}" "${3}"

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -7,6 +7,7 @@ function connect_interfaces () {
     sudo snap connect opensearch:process-control
     sudo snap connect opensearch:system-observe
     sudo snap connect opensearch:sys-fs-cgroup-service
+    sudo snap connect opensearch:shmem-perf-analyzer
 }
 
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -10,11 +10,11 @@ source "${OPS_ROOT}"/helpers/set-conf.sh
 
 function create_file_structure () {
     # Opensearch install folders and set config
-    dir_copy_if_not_exists "bin" "${SNAP_DATA}" 774
-    dir_copy_if_not_exists "jdk" "${SNAP_DATA}" 774
-    dir_copy_if_not_exists "lib" "${SNAP_DATA}" 554
-    dir_copy_if_not_exists "modules" "${SNAP_DATA}" 554
-    dir_copy_if_not_exists "plugins" "${SNAP_DATA}" 774
+    dir_copy_if_not_exists "bin" "${SNAP_DATA}" 770
+    dir_copy_if_not_exists "jdk" "${SNAP_DATA}" 770
+    dir_copy_if_not_exists "lib" "${SNAP_DATA}" 550
+    dir_copy_if_not_exists "modules" "${SNAP_DATA}" 550
+    dir_copy_if_not_exists "plugins" "${SNAP_DATA}" 770
 
     dir_copy_if_not_exists "config" "${SNAP_DATA}" 770
     add_folder "${SNAP_DATA}/config/certificates" 770
@@ -27,8 +27,7 @@ function create_file_structure () {
     add_folder "${SNAP_COMMON}/logs" 774
     add_folder "${SNAP_COMMON}/tmp" 770
 
-    # performance analyzer
-    mkdir -p "/dev/shm/performanceanalyzer/"
+    add_folder "/dev/shm/performanceanalyzer" 770
 }
 
 
@@ -39,6 +38,7 @@ function set_base_config_props () {
 
     replace_in_file "${SNAP_DATA}/config/jvm.options" "=logs/" "=${SNAP_COMMON}/logs/"
 }
+
 
 create_file_structure
 set_base_config_props

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -16,20 +16,19 @@ function create_file_structure () {
     dir_copy_if_not_exists "modules" "${SNAP_DATA}" 554
     dir_copy_if_not_exists "plugins" "${SNAP_DATA}" 774
 
-    dir_copy_if_not_exists "config" "${SNAP_DATA}" 774
-    add_folder "${SNAP_DATA}/config/certificates" 774
-    add_file "${SNAP_DATA}/config/unicast_hosts.txt" 774
+    dir_copy_if_not_exists "config" "${SNAP_DATA}" 770
+    add_folder "${SNAP_DATA}/config/certificates" 770
+    add_file "${SNAP_DATA}/config/unicast_hosts.txt" 770
 
-    add_folder "${SNAP_DATA}/extensions" 774
-    add_file "${SNAP_DATA}/extensions/extensions.yml" 774
+    add_folder "${SNAP_DATA}/extensions" 770
+    add_file "${SNAP_DATA}/extensions/extensions.yml" 770
 
-    add_folder "${SNAP_COMMON}/data" 774
+    add_folder "${SNAP_COMMON}/data" 770
     add_folder "${SNAP_COMMON}/logs" 774
-    add_folder "${SNAP_COMMON}/tmp" 774
+    add_folder "${SNAP_COMMON}/tmp" 770
 
     # performance analyzer
-    mkdir -p "/dev/shm/snap.${SNAP_INSTANCE_NAME}/performanceanalyzer/"
-    chmod -R 777 "/dev/shm/snap.${SNAP_INSTANCE_NAME}/performanceanalyzer/"
+    mkdir -p "/dev/shm/performanceanalyzer/"
 }
 
 
@@ -41,17 +40,5 @@ function set_base_config_props () {
     replace_in_file "${SNAP_DATA}/config/jvm.options" "=logs/" "=${SNAP_COMMON}/logs/"
 }
 
-
-function set_performance_analyzer_path () {
-    # change path of the metrics location directory of the performance analyzer
-    replace_in_file \
-        "${SNAP_DATA}/config/opensearch-performance-analyzer/performance-analyzer.properties" \
-        "metrics-location = /dev/shm/performanceanalyzer/" \
-        "metrics-location = /dev/shm/snap.${SNAP_INSTANCE_NAME}/performanceanalyzer/"
-}
-
-
 create_file_structure
 set_base_config_props
-
-set_performance_analyzer_path

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -9,30 +9,27 @@ source "${OPS_ROOT}"/helpers/set-conf.sh
 
 
 function create_file_structure () {
-    add_folder "${SNAP_COMMON}/backups" 774
-    ls -la "${SNAP_COMMON}"
-    ls -la "${SNAP_COMMON}/backups"
-    dir_copy_if_not_exists "config" "${SNAP_COMMON}/backups" 774
-
-    # -------------------------------
-
     # Opensearch install folders and set config
-    dir_copy_if_not_exists "bin" "${SNAP_DATA}" 770
-    dir_copy_if_not_exists "jdk" "${SNAP_DATA}" 770
-    dir_copy_if_not_exists "lib" "${SNAP_DATA}" 550
-    dir_copy_if_not_exists "modules" "${SNAP_DATA}" 550
-    dir_copy_if_not_exists "plugins" "${SNAP_DATA}" 770
+    dir_copy_if_not_exists "bin" "${SNAP_DATA}" 774
+    dir_copy_if_not_exists "jdk" "${SNAP_DATA}" 774
+    dir_copy_if_not_exists "lib" "${SNAP_DATA}" 554
+    dir_copy_if_not_exists "modules" "${SNAP_DATA}" 554
+    dir_copy_if_not_exists "plugins" "${SNAP_DATA}" 774
 
-    dir_copy_if_not_exists "config" "${SNAP_DATA}" 770
-    add_folder "${SNAP_DATA}/config/certificates" 770
-    add_file "${SNAP_DATA}/config/unicast_hosts.txt" 770
+    dir_copy_if_not_exists "config" "${SNAP_DATA}" 774
+    add_folder "${SNAP_DATA}/config/certificates" 774
+    add_file "${SNAP_DATA}/config/unicast_hosts.txt" 774
 
-    add_folder "${SNAP_DATA}/extensions" 770
-    add_file "${SNAP_DATA}/extensions/extensions.yml" 770
+    add_folder "${SNAP_DATA}/extensions" 774
+    add_file "${SNAP_DATA}/extensions/extensions.yml" 774
 
-    add_folder "${SNAP_COMMON}/data" 770
+    add_folder "${SNAP_COMMON}/data" 774
     add_folder "${SNAP_COMMON}/logs" 774
-    add_folder "${SNAP_COMMON}/tmp" 770
+    add_folder "${SNAP_COMMON}/tmp" 774
+
+    # performance analyzer
+    mkdir -p "/dev/shm/snap.${SNAP_INSTANCE_NAME}/performanceanalyzer/"
+    chmod -R 777 "/dev/shm/snap.${SNAP_INSTANCE_NAME}/performanceanalyzer/"
 }
 
 
@@ -45,5 +42,16 @@ function set_base_config_props () {
 }
 
 
+function set_performance_analyzer_path () {
+    # change path of the metrics location directory of the performance analyzer
+    replace_in_file \
+        "${SNAP_DATA}/config/opensearch-performance-analyzer/performance-analyzer.properties" \
+        "metrics-location = /dev/shm/performanceanalyzer/" \
+        "metrics-location = /dev/shm/snap.${SNAP_INSTANCE_NAME}/performanceanalyzer/"
+}
+
+
 create_file_structure
 set_base_config_props
+
+set_performance_analyzer_path

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,6 +73,7 @@ apps:
       - process-control
       - system-observe
       - sys-fs-cgroup-service
+      - performance-analyzer
     environment:
       OPS_ROOT: ${SNAP}/ops
       OPENSEARCH_PATH_CERTS: ${OPENSEARCH_PATH_CONF}/certificates

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,13 @@ system-usernames:
 
 
 plugs:
+  performance-analyzer:
+    interface: system-files
+    read:
+      - /dev/shm/performanceanalyzer
+    write:
+      - /dev/shm/performanceanalyzer
+
   sys-fs-cgroup-service:
     interface: system-files
     read:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,9 @@ system-usernames:
 
 
 plugs:
+  shmem-perf-analyzer:
+    interface: shared-memory
+    private: true
   sys-fs-cgroup-service:
     interface: system-files
     read:
@@ -33,6 +36,7 @@ hooks:
     plugs:
       - network
       - network-bind
+      - shmem-perf-analyzer
     environment:
       OPS_ROOT: ${SNAP}/ops
 
@@ -64,6 +68,7 @@ apps:
       - log-observe
       - mount-observe
       - process-control
+      - shmem-perf-analyzer
       - system-observe
       - sys-fs-cgroup-service
     environment:
@@ -164,3 +169,15 @@ parts:
         tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
       
         rm "${archive}"
+      
+        
+      
+#layout:
+#  /etc/opensearch/:
+#    symlink: ${SNAP_DATA}/config
+#  /var/lib/opensearch/:
+#    symlink: ${SNAP_DATA}/data
+#  /usr/share/opensearch/:
+#  /usr/share/opensearch/jdk:
+#  /usr/share/opensearch/lib:
+#  /usr/share/opensearch/lib:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,13 +23,6 @@ system-usernames:
 
 
 plugs:
-  performance-analyzer:
-    interface: system-files
-    read:
-      - /dev/shm/performanceanalyzer
-    write:
-      - /dev/shm/performanceanalyzer
-
   sys-fs-cgroup-service:
     interface: system-files
     read:
@@ -73,7 +66,6 @@ apps:
       - process-control
       - system-observe
       - sys-fs-cgroup-service
-      - performance-analyzer
     environment:
       OPS_ROOT: ${SNAP}/ops
       OPENSEARCH_PATH_CERTS: ${OPENSEARCH_PATH_CONF}/certificates

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -172,15 +172,3 @@ parts:
         tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
       
         rm "${archive}"
-      
-        
-      
-#layout:
-#  /etc/opensearch/:
-#    symlink: ${SNAP_DATA}/config
-#  /var/lib/opensearch/:
-#    symlink: ${SNAP_DATA}/data
-#  /usr/share/opensearch/:
-#  /usr/share/opensearch/jdk:
-#  /usr/share/opensearch/lib:
-#  /usr/share/opensearch/lib:


### PR DESCRIPTION
### Issue
This PR implements [DPE-2121](https://warthogs.atlassian.net/browse/DPE-2121), namely this PR: 
- adds support for the [Performance analyzer](https://opensearch.org/docs/latest/monitoring-your-cluster/pa/index/#storage), namely this PR adds a `read / write` plug for the path `/dev/shm/performanceanalyzer`

[DPE-2121]: https://warthogs.atlassian.net/browse/DPE-2121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ