### PR TITLE
Changed release channel format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  VERSION: 2.6.0
-
 on:
   workflow_call:
   pull_request:
@@ -23,6 +20,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Install required dependencies
+        run: |
+          sudo snap install yq
 
       - name: Upgrade linux deps
         run: |
@@ -47,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: opensearch_snap_amd64
-          path: opensearch_${{env.VERSION}}_amd64.snap
+          path: "opensearch_*.snap"
 
   test:
     name: Test Snap
@@ -64,8 +65,10 @@ jobs:
 
       - name: Install snap file
         run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          
           sudo snap remove --purge opensearch
-          sudo snap install opensearch_${{env.VERSION}}_amd64.snap --dangerous --jailmode
+          sudo snap install opensearch_${version}_amd64.snap --dangerous --jailmode
 
       - name: Setup the required system configs
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,11 @@ jobs:
     needs:
       - build
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Download snap file
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: Build OpenSearch from source, run tests and release.
 
 env:
-  VERSION: 2.6.0
   RELEASE: edge
 
 on:
@@ -21,16 +20,31 @@ jobs:
     needs:
       - ci-tests
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Install required dependencies
+        run: |
+          sudo snap install yq
+
       - name: Download snap file
         uses: actions/download-artifact@v3
         with:
           name: opensearch_snap_amd64
           path: .
 
+      - name: Set snap release channel
+        run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version%%.*}/${{env.RELEASE}}"
+          
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "channel=${channel}" >> $GITHUB_ENV
+
       - name: Publish snap to Store
         uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          snap: opensearch_${{env.VERSION}}_amd64.snap
-          release: ${{env.RELEASE}}
+          snap: opensearch_${{env.version}}_amd64.snap
+          release: ${{env.channel}}


### PR DESCRIPTION
This PR changes the release channel of the snap from previously `latest/edge` to now `2/edge` 