### PR TITLE
Unset cumulated classpath

### DIFF
--- a/scripts/wrappers/start.sh
+++ b/scripts/wrappers/start.sh
@@ -43,6 +43,9 @@ function start_opensearch () {
     exit_if_missing_perm "sys-fs-cgroup-service"
     exit_if_missing_perm "system-observe"
 
+    # unset cumulated classpath
+    unset OPENSEARCH_CLASSPATH
+
     # start
     "${SNAP}"/usr/bin/setpriv \
         --clear-groups \


### PR DESCRIPTION
This PR is about unsetting the `OPENSEARCH_CLASSPATH` env variable, to avoid it from being cumulated and hitting an `argument list too long` error after a few restarts.