### PR TITLE
Bump to 2.10.0 + replace of upstream tarball by build from sources one

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -29,7 +29,7 @@ function create_file_structure () {
     add_folder "${OPENSEARCH_HOME}/extensions" 770
     add_file "${OPENSEARCH_HOME}/extensions/extensions.yml" 660
     add_file "${OPENSEARCH_PATH_CONF}/unicast_hosts.txt" 660
-    add_folder "/dev/shm/performanceanalyzer" 770
+    [ -d "/dev/shm/performanceanalyzer" ] || add_folder "/dev/shm/performanceanalyzer" 770
 }
 
 
@@ -45,7 +45,9 @@ function set_base_config_props () {
 create_file_structure
 set_base_config_props
 
-chown -R snap_daemon "${SNAP_DATA}/"*
-chgrp root "${SNAP_DATA}/"*
-chown -R snap_daemon "${SNAP_COMMON}/"*
-chgrp root "${SNAP_COMMON}/"*
+#  "${SNAP_COMMON}"
+declare -a folders=("${SNAP_DATA}")
+for f in "${folders[@]}"; do
+    chown -R snap_daemon "${f}/"*
+    chgrp root "${f}/"*
+done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
 
-version: '2.9.0' # just for humans, typically '1.2+git' or '1.3.2'
+version: '2.10.0' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |
@@ -54,7 +54,7 @@ environment:
   OPS_ROOT: ${SNAP_CURRENT}/opt/opensearch
 
   OPENSEARCH_BIN: ${SNAP_CURRENT}/usr/share/opensearch/bin
-  OPENSEARCH_JAVA_HOME: ${SNAP_CURRENT}/usr/share/opensearch/jdk
+  OPENSEARCH_JAVA_HOME: ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64
 
   OPENSEARCH_HOME: ${SNAP_DATA_CURRENT}/usr/share/opensearch
   OPENSEARCH_LIB: ${OPENSEARCH_HOME}/lib
@@ -150,6 +150,7 @@ parts:
       - libpsm2-2-compat
       - libcrypt1
       - libexpat1
+      - openjdk-17-jdk-headless
       - zlib1g
 
   wrapper-scripts:
@@ -166,23 +167,27 @@ parts:
     plugin: nil
     override-build: |
         version="$(craftctl get version)"
-        archive="opensearch-${version}-linux-x64.tar.gz"
+        series="${version%%.*}.x"
+        patch="ubuntu0"
+        release_date="20231004122318"
       
-        curl -o "${archive}" "https://artifacts.opensearch.org/releases/bundle/opensearch/${version}/${archive}"
+        archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
+        url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"
+        curl -L -o "${archive}" "${url}"
         tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
-      
+
         mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch"
 
         mkdir -p "${CRAFT_PART_INSTALL}/etc/opensearch/"
         mv "${CRAFT_PART_INSTALL}"/config/* "${CRAFT_PART_INSTALL}/etc/opensearch/"
 
         declare -a resources=(
-            bin jdk lib modules plugins performance-analyzer-rca manifest.yml NOTICE.txt LICENSE.txt README.md
+            bin lib modules plugins performance-analyzer-rca manifest.yml NOTICE.txt LICENSE.txt README.md
         )
         for res in "${resources[@]}"; do
             mv "${CRAFT_PART_INSTALL}/${res}" "${CRAFT_PART_INSTALL}/usr/share/opensearch/"
         done
-        chmod -R 755 "${CRAFT_PART_INSTALL}/usr/share/opensearch/bin" "${CRAFT_PART_INSTALL}/usr/share/opensearch/jdk"
+        chmod -R 755 "${CRAFT_PART_INSTALL}/usr/share/opensearch/bin"
 
         # It is important to correct the user permissions for the opensearch.keystore file, after the script is executed.
         # Given we know which user is going to be used for the daemon, we can set this correction in the keystore script.


### PR DESCRIPTION
This PR:
- Bumps opensearch to 2.10.0
- Adds the JDK from the ubuntu archive
- Replaces the tarball used by the one produced from the LP build from sources.