### PR TITLE
[DPE-2934] add jmx exporter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,6 +224,29 @@ jobs:
               exit 1
           fi
 
+      - name: Check if Prometheus Exporter plugin is available
+        env:
+          OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-17-openjdk-amd64
+          OPENSEARCH_BIN: /snap/opensearch/current/usr/share/opensearch/bin
+          OPENSEARCH_PATH_CONF: /var/snap/opensearch/current/etc/opensearch
+          OPENSEARCH_HOME: /var/snap/opensearch/current/usr/share/opensearch
+          OPENSEARCH_LIB: /var/snap/opensearch/current/usr/share/opensearch/lib
+          OPENSEARCH_PATH_CERTS: /var/snap/opensearch/current/etc/opensearch/certificates
+        run: |
+          # Prometheus Exporter appears in plugins listing
+          prometheus_is_there=$(sudo -E "${OPENSEARCH_BIN}"/opensearch-plugin list | grep prometheus-exporter)
+          if [ ! "$prometheus_is_there" ]; then
+            exit 1
+          fi
+
+          # Prometheus exporter can be queried
+          sudo cp /var/snap/opensearch/current/etc/opensearch/certificates/node-cm0.pem ./
+          cert=./node-cm0.pem
+          resp=$(curl -I --cacert ${cert} -XGET https://localhost:9200/_prometheus/metrics -u 'admin:admin')
+          if [[ "$resp" != *"200 OK"* ]]; then
+            exit 1
+          fi
+
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -219,3 +219,22 @@ parts:
       for res in "${resources[@]}"; do
           rm -rf "${CRAFT_PART_INSTALL}/${res}"
       done
+
+  opensearch-plugin-prometheus-exporter:
+    plugin: nil
+    after: [opensearch]
+    override-build: |
+      # update deps
+      apt-get install unzip
+
+      version="$(craftctl get version).0"
+      archive="prometheus-exporter-${version}.zip"
+      url="https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/${version}/${archive}"
+      curl -L -o "${archive}" "${url}"
+
+      unzip "${archive}" -d "${CRAFT_PART_INSTALL}/prometheus-exporter"
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch/plugins"
+      mv "${CRAFT_PART_INSTALL}/prometheus-exporter" "${CRAFT_PART_INSTALL}/usr/share/opensearch/plugins"
+
+      # Final clean-up
+      rm "${archive}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -238,3 +238,22 @@ parts:
 
       # Final clean-up
       rm "${archive}"
+
+  jmx_exporter:
+    plugin: nil
+    after: [opensearch]
+    override-build: |
+      version="0.19.0"
+      archive="jmx_prometheus_javaagent-${version}.jar"
+
+      curl -o ${archive} "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${version}/${archive}"
+
+      EXPECTED_SHA="fb507001996c9af38709c110de32517f7592c818bb33e18bc5fe94e076d24c1f"
+      JAR_SHA=$(sha256sum ${archive} | cut -d " " -f1)
+      if [ $JAR_SHA != $EXPECTED_SHA ]; then exit 1; fi
+
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch/lib/"
+      cp ${archive} "${CRAFT_PART_INSTALL}/usr/share/opensearch/lib/"
+
+      # Final clean-up
+      rm "${archive}"


### PR DESCRIPTION
We can't put the `jmx_exporter` under plugins, as it's handled in a specific way by Opensearch and can't cope with a raw `.jar` file around.

So I thought to "dump" it to `lib`. Is that a good idea?