### PR TITLE
[DPE-3108] Prometheus configuration at startup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,6 +247,12 @@ jobs:
             exit 1
           fi
 
+          # Checking that Prometheus configuration is correct
+          prometheus_lines=$(sudo grep prometheus ${OPENSEARCH_PATH_CONF}/opensearch.yml | wc -l)
+          if [ "$prometheus_lines" != "4" ]; then
+            exit 1
+          fi
+
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -42,8 +42,17 @@ function set_base_config_props () {
 }
 
 
+function set_prometheus_exporter_config_props() {
+    set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "prometheus.metric_name.prefix" "opensearch_"
+    set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "prometheus.indices" "false"
+    set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "prometheus.cluster.settings" "false"
+    set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "prometheus.nodes.filter" "_local"
+}
+
+
 create_file_structure
 set_base_config_props
+set_prometheus_exporter_config_props
 
 #  "${SNAP_COMMON}"
 declare -a folders=("${SNAP_DATA}")


### PR DESCRIPTION
According to 

 - https://opensearch.org/blog/plugins-intro/ => Loading plugins

together with our experience, plugins installed in `$OPENSEARCH_HOME/plugins` are automatically loaded at startup.

Once we benefit from this feature, config should also get moved to the level of the snap.