### PR TITLE
[DPE-2938] Logs plug to snap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -253,6 +253,13 @@ jobs:
             exit 1
           fi
 
+      - name: Check COS logs slot is available
+        run: |
+          snap_slot=$( sudo snap connections opensearch | grep content )
+          if [ ! "$snap_slot" ]; then
+            exit 1
+          fi 
+
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,15 @@ plugs:
     read:
       - /sys/fs/cgroup/system.slice/snap.opensearch.daemon.service
 
+
+slots:
+  logs:
+    interface: content
+    source:
+      read:
+        - $SNAP_COMMON/var/log/opensearch
+
+
 hooks:
   install:
     plugs:
@@ -71,6 +80,7 @@ environment:
   OPENSEARCH_VARLOG: ${SNAP_COMMON}/var/log/opensearch
 
   KNN_LIB_DIR: ${OPENSEARCH_PLUGINS}/opensearch-knn/lib
+
 
 apps:
   daemon:


### PR DESCRIPTION
Still confirming with COS Team, but (based on existing DP charms' experience) it seems that need to allow [this](https://github.com/canonical/grafana-agent-snap/blob/main/snap/snapcraft.yaml#L19) to connect, so that logs could be shipped to COS. 

[Confirmation](https://matrix.to/#/!nHXpRkcSNJHlHdUGbQ:ubuntu.com/$eIG48CiRYmuuYzDg16c5AXDIVEwcH6xwzegiZdEkJac?via=ubuntu.com&via=matrix.org) from COS Team that the slot-plug connection is needed for strictly confined snaps. 
