### PR TITLE
[DPE-3309] Add support for repository-gcs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,7 +143,7 @@ jobs:
               exit 1
           fi
 
-      - name: Check if Prometheus Exporter and repository-s3 plugins are available
+      - name: Check if Prometheus Exporter and repository plugins are available
         env:
           OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-17-openjdk-amd64
           OPENSEARCH_BIN: /snap/opensearch/current/usr/share/opensearch/bin
@@ -160,6 +160,11 @@ jobs:
           # repository-s3 appears in plugins listing
           repository_s3_is_there=$(sudo -E "${OPENSEARCH_BIN}"/opensearch-plugin list | grep repository-s3)
           if [ ! "$repository_s3_is_there" ]; then
+            exit 1
+          fi
+          # repository-gcs appears in plugins listing
+          repository_gcs_is_there=$(sudo -E "${OPENSEARCH_BIN}"/opensearch-plugin list | grep repository-gcs)
+          if [ ! "$repository_gcs_is_there" ]; then
             exit 1
           fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -230,6 +230,22 @@ parts:
           rm -rf "${CRAFT_PART_INSTALL}/${res}"
       done
 
+  opensearch-plugin-repository-gcs:
+    plugin: nil
+    after: [opensearch]
+    override-build: |
+      # update deps
+      apt-get install unzip
+      version="$(craftctl get version)"
+      archive="repository-gcs-${version}.zip"
+      url="https://artifacts.opensearch.org/releases/plugins/repository-gcs/${version}/${archive}"
+      curl -L -o "${archive}" "${url}"
+      unzip "${archive}" -d "${CRAFT_PART_INSTALL}/repository-gcs"
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch/plugins"
+      mv "${CRAFT_PART_INSTALL}/repository-gcs" "${CRAFT_PART_INSTALL}/usr/share/opensearch/plugins"
+      # Final clean-up
+      rm "${archive}"
+
   opensearch-plugin-repository-s3:
     plugin: nil
     after: [opensearch]


### PR DESCRIPTION
This PR adds the `repository-gcs` plugin.

The plugin is downloaded from the artifacts.opensearch.org.