### PR TITLE
[DPE-3461] Add build from source v2.10.0-ubuntu1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -196,8 +196,8 @@ parts:
       # download opensearch tarball
       version="$(craftctl get version)"
       series="${version%%.*}.x"
-      patch="ubuntu0"
-      release_date="20231004122318"
+      patch="ubuntu1"
+      release_date="20240215162017"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"
@@ -229,41 +229,6 @@ parts:
       for res in "${resources[@]}"; do
           rm -rf "${CRAFT_PART_INSTALL}/${res}"
       done
-
-  opensearch-plugin-repository-gcs:
-    plugin: nil
-    after: [opensearch]
-    override-build: |
-      # update deps
-      apt-get install unzip
-      version="$(craftctl get version)"
-      archive="repository-gcs-${version}.zip"
-      url="https://artifacts.opensearch.org/releases/plugins/repository-gcs/${version}/${archive}"
-      curl -L -o "${archive}" "${url}"
-      unzip "${archive}" -d "${CRAFT_PART_INSTALL}/repository-gcs"
-      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch/plugins"
-      mv "${CRAFT_PART_INSTALL}/repository-gcs" "${CRAFT_PART_INSTALL}/usr/share/opensearch/plugins"
-      # Final clean-up
-      rm "${archive}"
-
-  opensearch-plugin-repository-s3:
-    plugin: nil
-    after: [opensearch]
-    override-build: |
-      # update deps
-      apt-get install unzip
-
-      version="$(craftctl get version)"
-      archive="repository-s3-${version}.zip"
-      url="https://artifacts.opensearch.org/releases/plugins/repository-s3/${version}/${archive}"
-      curl -L -o "${archive}" "${url}"
-
-      unzip "${archive}" -d "${CRAFT_PART_INSTALL}/repository-s3"
-      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch/plugins"
-      mv "${CRAFT_PART_INSTALL}/repository-s3" "${CRAFT_PART_INSTALL}/usr/share/opensearch/plugins"
-
-      # Final clean-up
-      rm "${archive}"
 
   opensearch-plugin-prometheus-exporter:
     plugin: nil


### PR DESCRIPTION
Extend the snap to download  the newer version of v2.10, containing core-plugins s3 and gcs.