### PR TITLE
Added badges to README.md

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Build OpenSearch from source, run tests and release.
+name: Publish to Snap Store
 
 env:
   RELEASE: edge

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # OpenSearch-Snap
+[![Build and Test](https://github.com/canonical/opensearch-snap/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/opensearch-snap/actions/workflows/ci.yaml)
+[![Publish](https://github.com/canonical/opensearch-snap/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/opensearch-snap/actions/workflows/release.yaml)
 
 [//]: # (<h1 align="center">)
 [//]: # (  <a href="https://opensearch.org/">)


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added workflow badges for 
* Publish to snap store
* Tests

and renamed workflow in `release.yaml` to "Publish to Snap Store".