### PR TITLE
[DPE-3647] Update to 2.11.1-ubuntu0 binaries

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -197,7 +197,7 @@ parts:
       version="$(craftctl get version)"
       series="${version%%.*}.x"
       patch="ubuntu0"
-      release_date="20240301072658"
+      release_date="20240306232827"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"
@@ -229,22 +229,3 @@ parts:
       for res in "${resources[@]}"; do
           rm -rf "${CRAFT_PART_INSTALL}/${res}"
       done
-
-  opensearch-plugin-prometheus-exporter:
-    plugin: nil
-    after: [opensearch]
-    override-build: |
-      # update deps
-      apt-get install unzip
-
-      version="$(craftctl get version)"
-      archive="prometheus-exporter-${version}-ubuntu0-20240119181708.zip"
-      url="https://launchpad.net/opensearch-plugin-prometheus-exporter-releases/2.x/exporter-${version}-ubuntu0/+download/"
-      curl  -L -o "${archive}" "${url}${archive}"
-
-      unzip "${archive}" -d "${CRAFT_PART_INSTALL}/prometheus-exporter"
-      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch/plugins"
-      mv "${CRAFT_PART_INSTALL}/prometheus-exporter" "${CRAFT_PART_INSTALL}/usr/share/opensearch/plugins"
-
-      # Final clean-up
-      rm "${archive}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
 
-version: '2.10.0' # just for humans, typically '1.2+git' or '1.3.2'
+version: '2.11.1' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |
@@ -196,8 +196,8 @@ parts:
       # download opensearch tarball
       version="$(craftctl get version)"
       series="${version%%.*}.x"
-      patch="ubuntu1"
-      release_date="20240215162017"
+      patch="ubuntu0"
+      release_date="20240301072658"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"


### PR DESCRIPTION
Update the OpenSearch binaries to use our built from source 2.11.1 version.