### PR TITLE
[DPE-3647] Update to 2.12.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,10 +111,10 @@ jobs:
           sudo snap start opensearch.daemon
 
           # wait a bit for it to fully initialize
-          sleep 45s
-
+          sleep 40s
           # create the security index
           sudo snap run opensearch.security-init --tls-priv-key-admin-pass=admin1234
+          sleep 15s
 
       - name: Ensure the cluster is reachable and node created
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
           sudo snap start opensearch.daemon
 
           # wait a bit for it to fully initialize
-          sleep 15s
+          sleep 45s
 
           # create the security index
           sudo snap run opensearch.security-init --tls-priv-key-admin-pass=admin1234

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Check if Prometheus Exporter and repository plugins are available
         env:
-          OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-17-openjdk-amd64
+          OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-21-openjdk-amd64
           OPENSEARCH_BIN: /snap/opensearch/current/usr/share/opensearch/bin
           OPENSEARCH_PATH_CONF: /var/snap/opensearch/current/etc/opensearch
           OPENSEARCH_HOME: /var/snap/opensearch/current/usr/share/opensearch
@@ -191,7 +191,7 @@ jobs:
 
       - name: Configure backup plugin 
         env:
-          OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-17-openjdk-amd64
+          OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-21-openjdk-amd64
           OPENSEARCH_BIN: /snap/opensearch/current/usr/share/opensearch/bin
           OPENSEARCH_PATH_CONF: /var/snap/opensearch/current/etc/opensearch
           OPENSEARCH_HOME: /var/snap/opensearch/current/usr/share/opensearch
@@ -257,7 +257,7 @@ jobs:
 
       - name: Remove backup plugin
         env:
-          OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-17-openjdk-amd64
+          OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-21-openjdk-amd64
           OPENSEARCH_BIN: /snap/opensearch/current/usr/share/opensearch/bin
           OPENSEARCH_PATH_CONF: /var/snap/opensearch/current/etc/opensearch
           OPENSEARCH_HOME: /var/snap/opensearch/current/usr/share/opensearch

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
 
-version: '2.11.1' # just for humans, typically '1.2+git' or '1.3.2'
+version: '2.12.0' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |
@@ -57,7 +57,7 @@ hooks:
 environment:
   SNAP_CURRENT: /snap/opensearch/current
   SNAP_DATA_CURRENT: /var/snap/opensearch/current
-  JAVA_HOME: ${SNAP}/usr/lib/jvm/java-17-openjdk-amd64
+  JAVA_HOME: ${SNAP}/usr/lib/jvm/java-21-openjdk-amd64
   PATH: ${JAVA_HOME}/jre/bin:$PATH
 
   SNAP_LOG_DIR: ${SNAP_COMMON}/ops/snap/logs
@@ -182,7 +182,7 @@ parts:
       - ssl-cert
       - openssl
     stage-packages:
-      - openjdk-17-jdk-headless
+      - openjdk-21-jdk-headless
     override-build: |
       # update deps
       apt-get update; apt-get upgrade -y; apt-get autoremove --purge -y; apt-get clean -y
@@ -197,7 +197,7 @@ parts:
       version="$(craftctl get version)"
       series="${version%%.*}.x"
       patch="ubuntu0"
-      release_date="20240306232827"
+      release_date="20240307123610"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"


### PR DESCRIPTION
Updates the OpenSearch to 2.12.0 built from source. Updates JDK to v21 and fixes CI.