### PR TITLE
DPE-2119 do not overwrite config on installation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RELEASE: edge
+
 on:
   workflow_call:
   pull_request:
@@ -52,6 +55,22 @@ jobs:
           name: opensearch_snap_amd64
           path: "opensearch_*.snap"
 
+      - name: Set snap release channel
+        run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version%%.*}/${{env.RELEASE}}"
+          
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "channel=${channel}" >> $GITHUB_ENV
+
+      - name: Publish snap to Store
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: opensearch_${{env.version}}_amd64.snap
+          release: ${{env.channel}}/dpe-2119
+          
   test:
     name: Test Snap
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           snap: opensearch_${{env.version}}_amd64.snap
           release: ${{env.channel}}/dpe-2119
-          
+
   test:
     name: Test Snap
     runs-on: ubuntu-latest

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -12,7 +12,7 @@ function create_file_structure () {
 
     # want to use the * here, so not calling dir_copy_if_not_exists
     # Doing it before OPENSEARCH_PATH_CERTS is created, as it is set as "snap_daemon" user
-    if [ ! -d "${OPENSEARCH_PATH_CONF}"]; then
+    if [ ! -d "${OPENSEARCH_PATH_CONF}" ]; then
         mkdir -p "${OPENSEARCH_PATH_CONF}/"
         copy_files_between_folder "${SNAP}/etc/opensearch/" "${OPENSEARCH_PATH_CONF}/"
     fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -12,8 +12,10 @@ function create_file_structure () {
 
     # want to use the * here, so not calling dir_copy_if_not_exists
     # Doing it before OPENSEARCH_PATH_CERTS is created, as it is set as "snap_daemon" user
-    mkdir -p "${OPENSEARCH_PATH_CONF}/"
-    copy_files_between_folder "${SNAP}/etc/opensearch/" "${OPENSEARCH_PATH_CONF}/"
+    if [ ! -d "${OPENSEARCH_PATH_CONF}"]; then
+        mkdir -p "${OPENSEARCH_PATH_CONF}/"
+        copy_files_between_folder "${SNAP}/etc/opensearch/" "${OPENSEARCH_PATH_CONF}/"
+    fi
 
     declare -a folders=("${OPENSEARCH_HOME}" "${OPENSEARCH_VARLIB}" "${OPENSEARCH_VARLOG}" "${OPENSEARCH_TMPDIR}" "${OPENSEARCH_PATH_CERTS}")
     for f in "${folders[@]}"; do


### PR DESCRIPTION
If storage is re-attached, snap installation currently overwrites existing opensearch configuration. This is fixed with this change.