### PR TITLE
[DPE-4732] Add support for homedir

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -15,7 +15,7 @@ function create_file_structure () {
     mkdir -p "${OPENSEARCH_PATH_CONF}/"
     copy_files_between_folder "${SNAP}/etc/opensearch/" "${OPENSEARCH_PATH_CONF}/"
 
-    declare -a folders=("${OPENSEARCH_HOME}" "${OPENSEARCH_VARLIB}" "${OPENSEARCH_VARLOG}" "${OPENSEARCH_TMPDIR}" "${OPENSEARCH_PATH_CERTS}")
+    declare -a folders=("${OPENSEARCH_HOME}" "${OPENSEARCH_VARLIB}" "${OPENSEARCH_VARLOG}" "${OPENSEARCH_TMPDIR}" "${OPENSEARCH_PATH_CERTS}" "${HOME}")
     for f in "${folders[@]}"; do
         if [ ! -d "${f}" ]; then
             add_folder "${f}" 770
@@ -41,6 +41,7 @@ function set_base_config_props () {
     set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "path.home" "${OPENSEARCH_HOME}"
 
     replace_in_file "${OPENSEARCH_PATH_CONF}/jvm.options" "=logs/" "=${OPENSEARCH_VARLOG}/"
+    echo "-Duser.home=${HOME}" | tee -a "${OPENSEARCH_PATH_CONF}/jvm.options"
 }
 
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,7 @@ environment:
   SNAP_DATA_CURRENT: /var/snap/opensearch/current
   JAVA_HOME: ${SNAP}/usr/lib/jvm/java-21-openjdk-amd64
   PATH: ${JAVA_HOME}/jre/bin:$PATH
+  HOME: ${SNAP_COMMON}/home/snap_daemon
 
   SNAP_LOG_DIR: ${SNAP_COMMON}/ops/snap/logs
 
@@ -89,7 +90,6 @@ apps:
     command: opt/opensearch/start.sh
     restart-condition: always
     restart-delay: 20s
-    # reload-command: ${SNAP}/usr/share/ops/start.sh
     plugs:
       - network
       - network-bind


### PR DESCRIPTION
Add support for home directory for snap_daemon both by setting `$HOME` and JVM's `-Duser.home`.

Closes #67 