### PR TITLE
[DPE-5047] Update snap to 2.14.0-ubuntu1 with ML Commons fix

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -197,8 +197,8 @@ parts:
       # download opensearch tarball
       version="$(craftctl get version)"
       series="${version%%.*}.x"
-      patch="ubuntu0"
-      release_date="20240527220320"
+      patch="ubuntu1"
+      release_date="20240805164805"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"


### PR DESCRIPTION
This PR backports upstream fix for ML Commons: https://github.com/opensearch-project/ml-commons/pull/2675

To be added to our distribution.

Given we are currently targeting upstream branch 2.14, instead of upstream tag 2.14.0.0, this build is using a new release from our build from source: 2.14.0-ubuntu1.