### PR TITLE
DPE-5919 - Update deprecating actions in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       snap-file: ${{ steps.build-snap.outputs.snap }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
           snapcraft-channel: 7.x/candidate
 
       - name: Upload built snap job artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opensearch_snap_amd64
           path: "opensearch_*.snap"
@@ -60,7 +60,7 @@ jobs:
       - build
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
           sudo snap refresh snapd
 
       - name: Download snap file
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: opensearch_snap_amd64
           path: .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,14 +21,14 @@ jobs:
       - ci-tests
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install required dependencies
         run: |
           sudo snap install yq
 
       - name: Download snap file
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: opensearch_snap_amd64
           path: .


### PR DESCRIPTION
Most v3 GitHub actions are being deprecated on November 30th.