### PR TITLE
[DPE-6324] Expose opensearch bin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,6 +146,11 @@ jobs:
           if [ ! "$repository_gcs_is_there" ]; then
             exit 1
           fi
+          # repository-azure appears in plugins listing
+          repository_azure_is_there=$(sudo opensearch.plugin list | grep repository-azure)
+          if [ ! "$repository_azure_is_there" ]; then
+            exit 1
+          fi
 
           # Prometheus exporter can be queried
           sudo cp /var/snap/opensearch/current/etc/opensearch/certificates/node-cm0.pem ./

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -283,8 +283,8 @@ parts:
       # download opensearch tarball
       version="$(craftctl get version)"
       series="${version%%.*}.x"
-      patch="ubuntu0"
-      release_date="20250114162335"
+      patch="ubuntu1"
+      release_date="20250114225302"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -132,7 +132,7 @@ apps:
       - network
       - network-bind
 
-  opensearch:
+  opensearch-bin:
     command: opt/opensearch/bin-wrapper.sh
     plugs:
       - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -132,6 +132,14 @@ apps:
       - network
       - network-bind
 
+  opensearch:
+    command: opt/opensearch/bin-wrapper.sh
+    plugs:
+      - network
+      - network-bind
+    environment:
+      bin_script: opensearch
+
   plugin:
     command: opt/opensearch/bin-wrapper.sh
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -284,7 +284,7 @@ parts:
       version="$(craftctl get version)"
       series="${version%%.*}.x"
       patch="ubuntu0"
-      release_date="20240919182113"
+      release_date="20250114162335"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"


### PR DESCRIPTION
- Adds missing `opensearch` bin (will enable correct version parsing on the charm)
- Update tarball with `repository-azure` preinstalled