### PR TITLE
[DPE-6817] Add QAT support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,3 +251,36 @@ jobs:
           sudo opensearch.plugin remove repository-s3
           sudo opensearch.keystore remove s3.client.default.access_key
           sudo opensearch.keystore remove s3.client.default.secret_key
+          
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - test
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Download snap file
+        uses: actions/download-artifact@v4
+        with:
+          name: opensearch_snap_amd64
+          path: .
+
+      - name: Set snap release channel
+        run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version%%.*}/${{env.RELEASE}}"
+          
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "channel=${channel}" >> $GITHUB_ENV
+
+      - name: Publish snap to Store
+        id: publish
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: opensearch_${{env.version}}_amd64.snap
+          release: qat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -283,4 +283,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: opensearch_${{env.version}}_amd64.snap
-          release: qat
+          release: ${{env.channel}}/test-qat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
       - name: Set snap release channel
         run: |
           version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/edge/test-qat"
+          channel="${version%%.*}/edge/qat-benchmark"
           
           echo "version=${version}" >> $GITHUB_ENV
           echo "channel=${channel}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,27 +251,11 @@ jobs:
           sudo opensearch.plugin remove repository-s3
           sudo opensearch.keystore remove s3.client.default.access_key
           sudo opensearch.keystore remove s3.client.default.secret_key
-          
-  publish:
-    name: publish
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs:
-      - test
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Download snap file
-        uses: actions/download-artifact@v4
-        with:
-          name: opensearch_snap_amd64
-          path: .
 
       - name: Set snap release channel
         run: |
           version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/${{env.RELEASE}}/test-qat"
+          channel="${version%%.*}/edge/test-qat"
           
           echo "version=${version}" >> $GITHUB_ENV
           echo "channel=${channel}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -271,7 +271,7 @@ jobs:
       - name: Set snap release channel
         run: |
           version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/${{env.RELEASE}}"
+          channel="${version%%.*}/${{env.RELEASE}}/test-qat"
           
           echo "version=${version}" >> $GITHUB_ENV
           echo "channel=${channel}" >> $GITHUB_ENV
@@ -283,4 +283,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: opensearch_${{env.version}}_amd64.snap
-          release: ${{env.channel}}/test-qat
+          release: ${{env.channel}}

--- a/scripts/wrappers/sys/set-sys-config.sh
+++ b/scripts/wrappers/sys/set-sys-config.sh
@@ -40,9 +40,7 @@ function set_ulimits () {
 
     # 3. Set the locked-in memory size to unlimited
     # ulimit -l 1964328 -- default in local machine
-    # if snapctl is-connected "process-control"; then
-    # ulimit -l unlimited
-    # fi
+    ulimit -l unlimited
 }
 
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -67,11 +67,8 @@ done
 # Changes for QAT support
 if lspci -k | grep -q qat_4xxx; then
     # shellcheck disable=SC2016
-    sed -i '/grant codeBase "${codebase.qat-java}" {/,/};/ {
-      /};/ i\
-    permission org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";
-    }' "${OPENSEARCH_PLUGINS}/opensearch-custom-codecs/plugin-security.policy"
-
-    # add the QAT group to the snap_daemon user
-    usermod -a -G qat snap_daemon
+    "${SNAP}"/usr/bin/setpriv --reuid snap_daemon -- bash -c 'sed -i "/grant codeBase \\\"\${codebase.qat-java}\\\" {/,/};/ {
+    /};/ i\\
+    permission org.opensearch.secure_sm.ThreadPermission \\"modifyArbitraryThread\\";
+    }" "${OPENSEARCH_PLUGINS}/opensearch-custom-codecs/plugin-security.policy"'
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -63,3 +63,15 @@ for f in "${folders[@]}"; do
     chown -R snap_daemon "${f}/"*
     chgrp root "${f}/"*
 done
+
+# Changes for QAT support
+if lspci -k | grep -q qat_4xxx; then
+    # shellcheck disable=SC2016
+    sed -i '/grant codeBase "${codebase.qat-java}" {/,/};/ {
+      /};/ i\
+    permission org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";
+    }' "${OPENSEARCH_PLUGINS}/opensearch-custom-codecs/plugin-security.policy"
+
+    # add the QAT group to the snap_daemon user
+    usermod -a -G qat snap_daemon
+fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -5,10 +5,10 @@ set -eux
 # Changes for QAT support
 if lspci -k | grep -q qat_4xxx; then
     # shellcheck disable=SC2016
-    sed -i '/grant codeBase "${codebase.qat-java}" {/,/};/ {
-      /};/ i\
-    permission org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";
-    }' "${OPENSEARCH_PLUGINS}/opensearch-custom-codecs/plugin-security.policy"
+    "${SNAP}"/usr/bin/setpriv --reuid snap_daemon -- bash -c 'sed -i "/grant codeBase \\\"\${codebase.qat-java}\\\" {/,/};/ {
+    /};/ i\\
+    permission org.opensearch.secure_sm.ThreadPermission \\"modifyArbitraryThread\\";
+    }" "${OPENSEARCH_PLUGINS}/opensearch-custom-codecs/plugin-security.policy"'
 
     # add the QAT group to the snap_daemon user
     usermod -a -G qat snap_daemon

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Changes for QAT support
+if lspci -k | grep -q qat_4xxx; then
+    # shellcheck disable=SC2016
+    sed -i '/grant codeBase "${codebase.qat-java}" {/,/};/ {
+      /};/ i\
+    permission org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";
+    }' "${OPENSEARCH_PLUGINS}/opensearch-custom-codecs/plugin-security.policy"
+
+    # add the QAT group to the snap_daemon user
+    usermod -a -G qat snap_daemon
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
 
-version: '2.18.0' # just for humans, typically '1.2+git' or '1.3.2'
+version: '2.19.1' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |
@@ -28,8 +28,6 @@ plugs:
     interface: system-files
     read:
       - /sys/fs/cgroup/system.slice/snap.opensearch.daemon.service
-  intel-qat:
-    interface: intel-qat
 
 slots:
   logs:
@@ -39,6 +37,7 @@ slots:
         - $SNAP_COMMON/var/log/opensearch
 
 hooks:
+  post-refresh:
   install:
     plugs:
       - network
@@ -46,7 +45,6 @@ hooks:
       - shmem-perf-analyzer
     environment:
       OPS_ROOT: ${SNAP_CURRENT}/opt/opensearch
-
   configure:
     environment:
       OPS_ROOT: ${SNAP_CURRENT}/opt/opensearch
@@ -284,8 +282,8 @@ parts:
       patch="ubuntu1"
       release_date="20250219193439"
 
-      archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
-      url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"
+      archive="opensearch-2.19.1-linux-x64.tar.gz"
+      url="https://artifacts.opensearch.org/releases/bundle/opensearch/2.19.1/opensearch-2.19.1-linux-x64.tar.gz"
       curl -L -o "${archive}" "${url}"
       tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,8 @@ slots:
 
 hooks:
   post-refresh:
+    environment:
+      OPS_ROOT: ${SNAP_CURRENT}/opt/opensearch
   install:
     plugs:
       - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -245,7 +245,7 @@ parts:
       - libcrypt1
       - libexpat1
       - zlib1g
-      - qatzip
+      - libqatzip3
 
   wrapper-scripts:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,10 +17,8 @@ confinement: strict # use 'strict' once you have the right plugs and slots
 platforms:
   amd64:
 
-
 system-usernames:
   snap_daemon: shared
-
 
 plugs:
   shmem-perf-analyzer:
@@ -30,7 +28,8 @@ plugs:
     interface: system-files
     read:
       - /sys/fs/cgroup/system.slice/snap.opensearch.daemon.service
-
+  intel-qat:
+    interface: intel-qat
 
 slots:
   logs:
@@ -38,7 +37,6 @@ slots:
     source:
       read:
         - $SNAP_COMMON/var/log/opensearch
-
 
 hooks:
   install:
@@ -52,7 +50,6 @@ hooks:
   configure:
     environment:
       OPS_ROOT: ${SNAP_CURRENT}/opt/opensearch
-
 
 environment:
   SNAP_CURRENT: /snap/opensearch/current
@@ -82,7 +79,6 @@ environment:
 
   KNN_LIB_DIR: ${OPENSEARCH_PLUGINS}/opensearch-knn/lib
 
-
 apps:
   daemon:
     daemon: simple
@@ -100,6 +96,7 @@ apps:
       - shmem-perf-analyzer
       - system-observe
       - sys-fs-cgroup-service
+      - intel-qat
     environment:
       LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:${KNN_LIB_DIR}"
 
@@ -248,7 +245,7 @@ parts:
       - libcrypt1
       - libexpat1
       - zlib1g
-
+      - qatzip
 
   wrapper-scripts:
     plugin: nil


### PR DESCRIPTION
This PR addresses [DPE-6817](https://warthogs.atlassian.net/browse/DPE-6817), namely this PR:
- adds support for QAT in the opensearch snap by:
  - setting `ulimit -l unlimited`
  - adding the permission `org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";` to the custom-codec's security policy
  - add the `intel-qat` interface

[DPE-6817]: https://warthogs.atlassian.net/browse/DPE-6817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ