### PR TITLE
[DPE-6817] Add QAT support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,3 +251,20 @@ jobs:
           sudo opensearch.plugin remove repository-s3
           sudo opensearch.keystore remove s3.client.default.access_key
           sudo opensearch.keystore remove s3.client.default.secret_key
+
+      - name: Set snap release channel
+        run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version%%.*}/edge/qat-benchmark"
+          
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "channel=${channel}" >> $GITHUB_ENV
+
+      - name: Publish snap to Store
+        id: publish
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: opensearch_${{env.version}}_amd64.snap
+          release: ${{env.channel}}

--- a/scripts/wrappers/bin-wrapper.sh
+++ b/scripts/wrappers/bin-wrapper.sh
@@ -2,7 +2,11 @@
 
 set -e
 
-"${SNAP}"/usr/bin/setpriv \
+if [ -z "${OPENSEARCH_JAVA_OPTS}" ]; then
+    OPENSEARCH_JAVA_OPTS="-Xms1g -Xmx1g"
+fi
+
+OPENSEARCH_JAVA_OPTS="${OPENSEARCH_JAVA_OPTS}" "${SNAP}"/usr/bin/setpriv \
     --clear-groups \
     --reuid snap_daemon \
     --regid snap_daemon -- \

--- a/scripts/wrappers/sys/set-sys-config.sh
+++ b/scripts/wrappers/sys/set-sys-config.sh
@@ -40,9 +40,7 @@ function set_ulimits () {
 
     # 3. Set the locked-in memory size to unlimited
     # ulimit -l 1964328 -- default in local machine
-    # if snapctl is-connected "process-control"; then
-    # ulimit -l unlimited
-    # fi
+    ulimit -l unlimited
 }
 
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -63,3 +63,12 @@ for f in "${folders[@]}"; do
     chown -R snap_daemon "${f}/"*
     chgrp root "${f}/"*
 done
+
+# Changes for QAT support
+if lspci -k | grep -q qat_4xxx; then
+    # shellcheck disable=SC2016
+    "${SNAP}"/usr/bin/setpriv --reuid snap_daemon -- bash -c 'sed -i "/grant codeBase \\\"\${codebase.qat-java}\\\" {/,/};/ {
+    /};/ i\\
+    permission org.opensearch.secure_sm.ThreadPermission \\"modifyArbitraryThread\\";
+    }" "${OPENSEARCH_PLUGINS}/opensearch-custom-codecs/plugin-security.policy"'
+fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Changes for QAT support
+if lspci -k | grep -q qat_4xxx; then
+    # shellcheck disable=SC2016
+    "${SNAP}"/usr/bin/setpriv --reuid snap_daemon -- bash -c 'sed -i "/grant codeBase \\\"\${codebase.qat-java}\\\" {/,/};/ {
+    /};/ i\\
+    permission org.opensearch.secure_sm.ThreadPermission \\"modifyArbitraryThread\\";
+    }" "${OPENSEARCH_PLUGINS}/opensearch-custom-codecs/plugin-security.policy"'
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
 
-version: '2.18.0' # just for humans, typically '1.2+git' or '1.3.2'
+version: '2.19.1' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |
@@ -17,10 +17,8 @@ confinement: strict # use 'strict' once you have the right plugs and slots
 platforms:
   amd64:
 
-
 system-usernames:
   snap_daemon: shared
-
 
 plugs:
   shmem-perf-analyzer:
@@ -31,7 +29,6 @@ plugs:
     read:
       - /sys/fs/cgroup/system.slice/snap.opensearch.daemon.service
 
-
 slots:
   logs:
     interface: content
@@ -39,8 +36,10 @@ slots:
       read:
         - $SNAP_COMMON/var/log/opensearch
 
-
 hooks:
+  post-refresh:
+    environment:
+      OPS_ROOT: ${SNAP_CURRENT}/opt/opensearch
   install:
     plugs:
       - network
@@ -48,11 +47,9 @@ hooks:
       - shmem-perf-analyzer
     environment:
       OPS_ROOT: ${SNAP_CURRENT}/opt/opensearch
-
   configure:
     environment:
       OPS_ROOT: ${SNAP_CURRENT}/opt/opensearch
-
 
 environment:
   SNAP_CURRENT: /snap/opensearch/current
@@ -82,7 +79,6 @@ environment:
 
   KNN_LIB_DIR: ${OPENSEARCH_PLUGINS}/opensearch-knn/lib
 
-
 apps:
   daemon:
     daemon: simple
@@ -100,6 +96,7 @@ apps:
       - shmem-perf-analyzer
       - system-observe
       - sys-fs-cgroup-service
+      - intel-qat
     environment:
       LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:${KNN_LIB_DIR}"
 
@@ -248,7 +245,7 @@ parts:
       - libcrypt1
       - libexpat1
       - zlib1g
-
+      - libqatzip3
 
   wrapper-scripts:
     plugin: nil
@@ -287,8 +284,8 @@ parts:
       patch="ubuntu1"
       release_date="20250219193439"
 
-      archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
-      url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"
+      archive="opensearch-2.19.1-linux-x64.tar.gz"
+      url="https://artifacts.opensearch.org/releases/bundle/opensearch/2.19.1/opensearch-2.19.1-linux-x64.tar.gz"
       curl -L -o "${archive}" "${url}"
       tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
 


### PR DESCRIPTION
This PR addresses [DPE-6817](https://warthogs.atlassian.net/browse/DPE-6817), namely this PR:
- adds support for QAT in the opensearch snap by:
  - setting `ulimit -l unlimited`
  - adding the permission `org.opensearch.secure_sm.ThreadPermission "modifyArbitraryThread";` to the custom-codec's security policy
  - add the `intel-qat` interface

[DPE-6817]: https://warthogs.atlassian.net/browse/DPE-6817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ