### PR TITLE
Release 2.19.1-ubuntu1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -284,8 +284,8 @@ parts:
       # download opensearch tarball
       version="$(craftctl get version)"
       series="${version%%.*}.x"
-      patch="ubuntu0"
-      release_date="20250409183335"
+      patch="ubuntu1"
+      release_date="20250411151204"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"


### PR DESCRIPTION
This PR releases build 2.19.1 with ubuntu1 which backports a fix for query insights

After the fix has been backported to `query-insights`, we can see a single unit does come up without replicas:
```
.opensearch-observability        0 p STARTED     0   208b 10.101.48.1 cm0
.plugins-ml-config               0 p STARTED     1  3.9kb 10.101.48.1 cm0
top_queries-2025.04.11-51453     0 p STARTED     4 56.9kb 10.101.48.1 cm0
test                             0 p STARTED     0   208b 10.101.48.1 cm0
test                             0 r UNASSIGNED                       
.opensearch-sap-log-types-config 0 p STARTED              10.101.48.1 cm0
.opendistro_security             0 p STARTED    10 82.1kb 10.101.48.1 cm0
```