### PR TITLE
Add Intel Quick Assist (QAT) support

### DIFF
--- a/scripts/wrappers/start.sh
+++ b/scripts/wrappers/start.sh
@@ -37,6 +37,22 @@ function set_defaults () {
     fi
 }
 
+# Since the daemon is running under snap_daemon:snap_daemon
+# It cannot access the QAT VFIO devices that are owned by
+# root:qat.
+# One solution would be adding the group qat to the user
+# snap_daemon but as of now, snapd does not allow to do that.
+# The solution is to give the group snap_daemon this access
+# by ACL.
+# All VFIO devices owned by the group qat will be configured
+# to allow RW access for snap_daemon group.
+function configure_qat() {
+    find /dev/vfio/ -maxdepth 1 -exec sh -c '
+      stat -c "%U %G" "$1" |
+      awk -F " " "\$2!=\"qat\"{exit 1}"
+   ' sh {} \; -exec ${SNAP}/usr/bin/setfacl -m group:snap_daemon:rw {} \;
+}
+
 function start_opensearch () {
     exit_if_missing_perm "log-observe"
     exit_if_missing_perm "mount-observe"
@@ -44,6 +60,8 @@ function start_opensearch () {
     exit_if_missing_perm "system-observe"
 
     warn_if_missing_perm "process-control"
+
+    configure_qat
 
     # start
     "${SNAP}"/usr/bin/setpriv \

--- a/scripts/wrappers/start.sh
+++ b/scripts/wrappers/start.sh
@@ -47,10 +47,11 @@ function set_defaults () {
 # All VFIO devices owned by the group qat will be configured
 # to allow RW access for snap_daemon group.
 function configure_qat() {
-    find /dev/vfio/ -maxdepth 1 -exec sh -c '
-      stat -c "%U %G" "$1" |
-      awk -F " " "\$2!=\"qat\"{exit 1}"
-   ' sh {} \; -exec ${SNAP}/usr/bin/setfacl -m group:snap_daemon:rw {} \;
+    qat_group="qat"
+    if $(getent group "${qat_group}" >/dev/null); then
+      find /dev/vfio/ -maxdepth 1 -group "${qat_group}" \
+        -exec ${SNAP}/usr/bin/setfacl -m group:snap_daemon:rw {} \;
+    fi
 }
 
 function start_opensearch () {

--- a/scripts/wrappers/sys/set-sys-config.sh
+++ b/scripts/wrappers/sys/set-sys-config.sh
@@ -40,9 +40,7 @@ function set_ulimits () {
 
     # 3. Set the locked-in memory size to unlimited
     # ulimit -l 1964328 -- default in local machine
-    # if snapctl is-connected "process-control"; then
-    # ulimit -l unlimited
-    # fi
+    ulimit -l unlimited
 }
 
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,6 +100,7 @@ apps:
       - shmem-perf-analyzer
       - system-observe
       - sys-fs-cgroup-service
+      - intel-qat
     environment:
       LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:${KNN_LIB_DIR}"
 
@@ -248,6 +249,7 @@ parts:
       - libcrypt1
       - libexpat1
       - zlib1g
+      - libqatzip3
 
 
   wrapper-scripts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -250,6 +250,7 @@ parts:
       - libexpat1
       - zlib1g
       - libqatzip3
+      - acl
 
 
   wrapper-scripts:


### PR DESCRIPTION
This MR enables QAT support for opensearch by:
 - Adding QAT libraries into the opensearch snap (based on Ubuntu 24.04)
 - Adding the interface intel-qat 
 - Remove the limit on the amount of lock memory a process can request. This is required by VFIO subsystem.

With these modifications, opensearch still expects the QAT to be initialized and configured on the host platform.
This can be done by installing `qatlib-service` and run the init script.

```
$ sudo apt install -y qatlib-service
$ sudo /usr/sbin/qat_init.sh
```
