### PR TITLE
[DPE-7503] Release opensearch 2.19.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
 
-version: '2.19.1' # just for humans, typically '1.2+git' or '1.3.2'
+version: '2.19.2' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |
@@ -287,8 +287,8 @@ parts:
       # download opensearch tarball
       version="$(craftctl get version)"
       series="${version%%.*}.x"
-      patch="ubuntu1"
-      release_date="20250411151204"
+      patch="ubuntu0"
+      release_date="20250623142957"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -301,7 +301,7 @@ parts:
       mv "${CRAFT_PART_INSTALL}"/config/* "${CRAFT_PART_INSTALL}/etc/opensearch/"
 
       declare -a resources=(
-          bin lib modules plugins performance-analyzer-rca manifest.yml NOTICE.txt LICENSE.txt README.md
+          bin lib modules plugins manifest.yml NOTICE.txt LICENSE.txt README.md
       )
       for res in "${resources[@]}"; do
           mv "${CRAFT_PART_INSTALL}/${res}" "${CRAFT_PART_INSTALL}/usr/share/opensearch/"


### PR DESCRIPTION
This PR releases the version `2.19.2` of the opensearch snap along with 2 upstream fixes:
- https://github.com/opensearch-project/custom-codecs/pull/252
- https://github.com/opensearch-project/custom-codecs/pull/254

In the process - this PR also removes references to the now deprecated `performance-analyzer-rca` component:
- https://github.com/opensearch-project/performance-analyzer-rca/issues/591 