### PR TITLE
add guard to avoid crash + use full path for curl and yq

### DIFF
--- a/scripts/wrappers/sys/set-sys-config.sh
+++ b/scripts/wrappers/sys/set-sys-config.sh
@@ -40,7 +40,7 @@ function set_ulimits () {
 
     # 3. Set the locked-in memory size to unlimited
     # ulimit -l 1964328 -- default in local machine
-    ulimit -l unlimited
+    ulimit -l unlimited || true
 }
 
 

--- a/scripts/wrappers/tests/test-cluster-health-green.sh
+++ b/scripts/wrappers/tests/test-cluster-health-green.sh
@@ -58,10 +58,10 @@ set_defaults
 # Check cluster health
 endpoint="https://localhost:9200/_cluster/health"
 
-health_resp=$(curl -sk -XGET "${endpoint}" -u "admin:${admin_auth_password}")
+health_resp=$(${SNAP_CURRENT}/usr/bin/curl -sk -XGET "${endpoint}" -u "admin:${admin_auth_password}")
 echo -e "Cluster Health Response: \n ${health_resp}"
 
-cluster_status=$(echo "${health_resp}" | yq -r .status)
+cluster_status=$(echo "${health_resp}" | ${SNAP_CURRENT}/bin/yq -r .status)
 if [ "${cluster_status}" != "green" ]; then
     exit 1
 fi

--- a/scripts/wrappers/tests/test-node-up.sh
+++ b/scripts/wrappers/tests/test-node-up.sh
@@ -69,10 +69,10 @@ set_defaults
 # Check node name
 endpoint="https://localhost:9200"
 
-cluster_resp=$(curl -sk -XGET "${endpoint}" -u "admin:${admin_auth_password}")
+cluster_resp=$(${SNAP_CURRENT}/usr/bin/curl -sk -XGET "${endpoint}" -u "admin:${admin_auth_password}")
 echo -e "Cluster Response: \n ${cluster_resp}"
 
-node_name_resp=$(echo "${cluster_resp}" | yq -r .name)
+node_name_resp=$(echo "${cluster_resp}" | ${SNAP_CURRENT}/bin/yq -r .name)
 if [ "${node_name_resp}" != "${node_name}" ]; then
     exit 1
 fi

--- a/scripts/wrappers/tests/test-security-index-created.sh
+++ b/scripts/wrappers/tests/test-security-index-created.sh
@@ -58,7 +58,7 @@ set_defaults
 # Check cluster health
 endpoint="https://localhost:9200/.opendistro_security"
 
-sec_index_resp=$(curl -k -I -s -o /dev/null -w "%{http_code}" "${endpoint}" -u "admin:${admin_auth_password}")
+sec_index_resp=$(${SNAP_CURRENT}/usr/bin/curl -k -I -s -o /dev/null -w "%{http_code}" "${endpoint}" -u "admin:${admin_auth_password}")
 echo -e "Security index response: \n ${sec_index_resp}"
 
 if [ "${sec_index_resp}" != "200" ]; then


### PR DESCRIPTION
The charm fails to run the `ulimit` command in lxd environments. This PR ensures that the call doesn't cause a crash.

This PR also uses the full path for `curl` and `yq` so that the test commands in our README work.