### PR TITLE
[DPE-7050] - add editable java cacerts trust store

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,20 +251,3 @@ jobs:
           sudo opensearch.plugin remove repository-s3
           sudo opensearch.keystore remove s3.client.default.access_key
           sudo opensearch.keystore remove s3.client.default.secret_key
-
-      - name: Set snap release channel
-        run: |
-          version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/edge/cacerts"
-          
-          echo "version=${version}" >> $GITHUB_ENV
-          echo "channel=${channel}" >> $GITHUB_ENV
-
-      - name: Publish snap to Store
-        id: publish
-        uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: opensearch_${{env.version}}_amd64.snap
-          release: ${{env.channel}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,3 +251,20 @@ jobs:
           sudo opensearch.plugin remove repository-s3
           sudo opensearch.keystore remove s3.client.default.access_key
           sudo opensearch.keystore remove s3.client.default.secret_key
+
+      - name: Set snap release channel
+        run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version%%.*}/${{env.RELEASE}}/cacerts"
+          
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "channel=${channel}" >> $GITHUB_ENV
+
+      - name: Publish snap to Store
+        id: publish
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: opensearch_${{env.version}}_amd64.snap
+          release: ${{env.channel}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
       - name: Set snap release channel
         run: |
           version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/edge/cacerts/"
+          channel="${version%%.*}/edge/cacerts"
           
           echo "version=${version}" >> $GITHUB_ENV
           echo "channel=${channel}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
       - name: Set snap release channel
         run: |
           version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/${{env.RELEASE}}/cacerts"
+          channel="${version%%.*}/${{env.RELEASE}}cacerts/"
           
           echo "version=${version}" >> $GITHUB_ENV
           echo "channel=${channel}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
       - name: Set snap release channel
         run: |
           version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/${{env.RELEASE}}cacerts/"
+          channel="${version%%.*}/edge/cacerts/"
           
           echo "version=${version}" >> $GITHUB_ENV
           echo "channel=${channel}" >> $GITHUB_ENV

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -52,10 +52,27 @@ function set_prometheus_exporter_config_props() {
     set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "prometheus.nodes.filter" "_local"
 }
 
+function create_editable_cacerts_trust_store() {
+    # Copy the read only JDK provided cacerts into a writeable one
+    "${SNAP}"/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool \
+        -importkeystore                                     \
+        -srckeystore  "${SNAP}/etc/ssl/certs/java/cacerts"  \
+        -destkeystore "${SNAP_DATA}"/etc/opensearch/certificates/cacerts.p12 \
+        -srcstoretype   JKS              \
+        -deststoretype  PKCS12           \
+        -srcstorepass   changeit         \
+        -deststorepass  changeit         \
+        -noprompt
+
+    echo "-Djavax.net.ssl.trustStore=/var/snap/opensearch/current/etc/opensearch/certificates/cacerts.p12" | tee -a "${OPENSEARCH_PATH_CONF}/jvm.options"
+    echo "-Djavax.net.ssl.trustStorePassword=changeit" | tee -a "${OPENSEARCH_PATH_CONF}/jvm.options"
+}
+
 
 create_file_structure
 set_base_config_props
 set_prometheus_exporter_config_props
+create_editable_cacerts_trust_store
 
 #  "${SNAP_COMMON}"
 declare -a folders=("${SNAP_DATA}")
@@ -64,16 +81,3 @@ for f in "${folders[@]}"; do
     chgrp root "${f}/"*
 done
 
-# Copy the read only JDK provided cacerts into a writeable one
-"${SNAP}"/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool \
-    -importkeystore                                     \
-    -srckeystore  "${SNAP}/etc/ssl/certs/java/cacerts"  \
-    -destkeystore "${SNAP_DATA}"/etc/opensearch/certificates/cacerts.p12 \
-    -srcstoretype   JKS              \
-    -deststoretype  PKCS12           \
-    -srcstorepass   changeit         \
-    -deststorepass  changeit         \
-    -noprompt
-
-echo "-Djavax.net.ssl.trustStore=/var/snap/opensearch/current/etc/opensearch/certificates/cacerts.p12" | tee -a "${OPENSEARCH_PATH_CONF}/jvm.options"
-echo "-Djavax.net.ssl.trustStorePassword=changeit" | tee -a "${OPENSEARCH_PATH_CONF}/jvm.options"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -63,3 +63,17 @@ for f in "${folders[@]}"; do
     chown -R snap_daemon "${f}/"*
     chgrp root "${f}/"*
 done
+
+# Copy the read only JDK provided cacerts into a writeable one
+"${SNAP}"/usr/lib/jvm/java-21-openjdk-amd64/bin/keytool \
+    -importkeystore                                     \
+    -srckeystore  "${SNAP}/etc/ssl/certs/java/cacerts"  \
+    -destkeystore "${SNAP_DATA}"/etc/opensearch/certificates/cacerts.p12 \
+    -srcstoretype   JKS              \
+    -deststoretype  PKCS12           \
+    -srcstorepass   changeit         \
+    -deststorepass  changeit         \
+    -noprompt
+
+echo "-Djavax.net.ssl.trustStore=/var/snap/opensearch/current/etc/opensearch/certificates/cacerts.p12" | tee -a "${OPENSEARCH_PATH_CONF}/jvm.options"
+echo "-Djavax.net.ssl.trustStorePassword=changeit" | tee -a "${OPENSEARCH_PATH_CONF}/jvm.options"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -80,4 +80,3 @@ for f in "${folders[@]}"; do
     chown -R snap_daemon "${f}/"*
     chgrp root "${f}/"*
 done
-


### PR DESCRIPTION
This PR implements [DPE-7050](https://warthogs.atlassian.net/browse/DPE-7050). Specifically, this PR:
- adds a custom trust store to `SNAP_DATA` - that's a copy to the default jdk shipped JKS cacerts trust store
- starts opensearch with this trust store

[DPE-7050]: https://warthogs.atlassian.net/browse/DPE-7050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ