### PR TITLE
[DPE-7803] 3.x Snap without non-core plugins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RELEASE: edge
+
 on:
   workflow_call:
   pull_request:
@@ -30,6 +33,23 @@ jobs:
         with:
           name: opensearch_snap_amd64
           path: "opensearch_*.snap"
+
+      - name: Set snap release channel
+        run: |
+          sudo snap install yq
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version%%.*}/${{env.RELEASE}}"
+          
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "channel=${channel}" >> $GITHUB_ENV
+          
+      - name: Publish snap to Store
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: opensearch_${{env.version}}_amd64.snap
+          release: ${{env.channel}}/dpe-7403
 
   test:
     name: Test Snap

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  RELEASE: edge
-
 on:
   workflow_call:
   pull_request:
@@ -33,23 +30,6 @@ jobs:
         with:
           name: opensearch_snap_amd64
           path: "opensearch_*.snap"
-
-      - name: Set snap release channel
-        run: |
-          sudo snap install yq
-          version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/${{env.RELEASE}}"
-          
-          echo "version=${version}" >> $GITHUB_ENV
-          echo "channel=${channel}" >> $GITHUB_ENV
-          
-      - name: Publish snap to Store
-        uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: opensearch_${{env.version}}_amd64.snap
-          release: ${{env.channel}}/dpe-7403
 
   test:
     name: Test Snap

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - '2/edge'
+      - '3/edge'
   workflow_call:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ analytics suite that makes it easy to ingest, search, visualize, and analyze dat
 
 or:
 ```
-sudo snap install opensearch --channel=2/edge
+sudo snap install opensearch --channel=3/edge
 sudo snap connect opensearch:process-control
 ```
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -41,6 +41,7 @@ function set_base_config_props () {
     set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "path.home" "${OPENSEARCH_HOME}"
 
     replace_in_file "${OPENSEARCH_PATH_CONF}/jvm.options" "=logs/" "=${OPENSEARCH_VARLOG}/"
+    replace_in_file "${OPENSEARCH_PATH_CONF}/jvm.options" "-javaagent:" "-javaagent:${SNAP_CURRENT}/"
     echo "-Duser.home=${HOME}" | tee -a "${OPENSEARCH_PATH_CONF}/jvm.options"
 }
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -309,12 +309,6 @@ parts:
       mkdir -p "${CRAFT_PART_INSTALL}/etc/opensearch/"
       mv "${CRAFT_PART_INSTALL}"/config/* "${CRAFT_PART_INSTALL}/etc/opensearch/"
 
-      AGENT_JAR_PATH="/snap/opensearch/current/agent/opensearch-agent.jar"
-      JVM_OPTIONS_FILE="${CRAFT_PART_INSTALL}/etc/opensearch/jvm.options"
-
-      # Replace -javaagent path
-      sed -i "s|^21-:-javaagent:.*|21-:-javaagent:${AGENT_JAR_PATH}|" "$JVM_OPTIONS_FILE"
-
       declare -a resources=(
           bin lib modules plugins manifest.yml NOTICE.txt LICENSE.txt README.md
       )

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: opensearch # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
 
-version: '2.19.2' # just for humans, typically '1.2+git' or '1.3.2'
+version: '3.1.0' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |
@@ -288,7 +288,7 @@ parts:
       version="$(craftctl get version)"
       series="${version%%.*}.x"
       patch="ubuntu0"
-      release_date="20250623142957"
+      release_date="20250729150601"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -288,7 +288,7 @@ parts:
       version="$(craftctl get version)"
       series="${version%%.*}.x"
       patch="ubuntu0"
-      release_date="20250729150601"
+      release_date="20250730162625"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -309,6 +309,12 @@ parts:
       mkdir -p "${CRAFT_PART_INSTALL}/etc/opensearch/"
       mv "${CRAFT_PART_INSTALL}"/config/* "${CRAFT_PART_INSTALL}/etc/opensearch/"
 
+      AGENT_JAR_PATH="/snap/opensearch/current/agent/opensearch-agent.jar"
+      JVM_OPTIONS_FILE="${CRAFT_PART_INSTALL}/etc/opensearch/jvm.options"
+
+      # Replace -javaagent path
+      sed -i "s|^21-:-javaagent:.*|21-:-javaagent:${AGENT_JAR_PATH}|" "$JVM_OPTIONS_FILE"
+
       declare -a resources=(
           bin lib modules plugins manifest.yml NOTICE.txt LICENSE.txt README.md
       )


### PR DESCRIPTION
This PR:
- Bumps the version to 3.1.0 and updates tarball url
- Updates the release workflow to trigger on `3/edge` branch
- Updates the installation channel in the README
- Sets the javaagent path to the [new java agent](https://github.com/opensearch-project/project-website/blob/82b6288a5b933307b98a0e2c0639d7f7fee62c52/_posts/2025-05-19-journey-to-find-replacements-java-security-manager.md#java-agent) in the install hook

Addresses [DPE-7803]

[DPE-7803]: https://warthogs.atlassian.net/browse/DPE-7803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ