### PR TITLE
Add refresh hooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,3 +251,19 @@ jobs:
           sudo opensearch.plugin remove repository-s3
           sudo opensearch.keystore remove s3.client.default.access_key
           sudo opensearch.keystore remove s3.client.default.secret_key
+
+      - name: Set snap release channel
+        run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version%%.*}/edge/hooks"
+          
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "channel=${channel}" >> $GITHUB_ENV
+      - name: Publish snap to Store
+        id: publish
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: opensearch_${{env.version}}_amd64.snap
+          release: ${{env.channel}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,19 +251,3 @@ jobs:
           sudo opensearch.plugin remove repository-s3
           sudo opensearch.keystore remove s3.client.default.access_key
           sudo opensearch.keystore remove s3.client.default.secret_key
-
-      - name: Set snap release channel
-        run: |
-          version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/edge/upgrades"
-          
-          echo "version=${version}" >> $GITHUB_ENV
-          echo "channel=${channel}" >> $GITHUB_ENV
-      - name: Publish snap to Store
-        id: publish
-        uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: opensearch_${{env.version}}_amd64.snap
-          release: ${{env.channel}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,3 +251,19 @@ jobs:
           sudo opensearch.plugin remove repository-s3
           sudo opensearch.keystore remove s3.client.default.access_key
           sudo opensearch.keystore remove s3.client.default.secret_key
+
+      - name: Set snap release channel
+        run: |
+          version="$(cat snap/snapcraft.yaml | yq .version)"
+          channel="${version%%.*}/edge/upgrades"
+          
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "channel=${channel}" >> $GITHUB_ENV
+      - name: Publish snap to Store
+        id: publish
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: opensearch_${{env.version}}_amd64.snap
+          release: ${{env.channel}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,19 +251,3 @@ jobs:
           sudo opensearch.plugin remove repository-s3
           sudo opensearch.keystore remove s3.client.default.access_key
           sudo opensearch.keystore remove s3.client.default.secret_key
-
-      - name: Set snap release channel
-        run: |
-          version="$(cat snap/snapcraft.yaml | yq .version)"
-          channel="${version%%.*}/edge/hooks"
-          
-          echo "version=${version}" >> $GITHUB_ENV
-          echo "channel=${channel}" >> $GITHUB_ENV
-      - name: Publish snap to Store
-        id: publish
-        uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: opensearch_${{env.version}}_amd64.snap
-          release: ${{env.channel}}

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -4,25 +4,6 @@ set -eux
 
 source "${OPS_ROOT}"/helpers/snap-logger.sh "hook-post-refresh"
 
-set_previous_revision() {
-    for candidate in "${SNAP_DATA}"/../*; do
-        revision=$(basename "${candidate}")
-
-        # skip 'common', 'current' and current revision
-        [[ "${revision}" == "common" ]] && continue
-        [[ "${revision}" == "current" ]] && continue
-        [[ "${revision}" == "${SNAP_REVISION}" ]] && continue
-
-        revision_opensearch_home="${candidate}/usr/share/opensearch"
-
-        [[ -d "${revision_opensearch_home}" ]] || continue
-        if diff -qr "${OPENSEARCH_HOME}" "$revision_opensearch_home" >/dev/null 2>&1; then
-            snapctl set last-revision=${revision}
-            return 0
-        fi
-    done
-}
-
 replace_stale_jars() {
     declare -a common=(modules plugins lib)
     for dir in "${common[@]}"; do
@@ -30,7 +11,6 @@ replace_stale_jars() {
     done
 }
 
-set_previous_revision
 setpriv \
     --clear-groups \
     --reuid snap_daemon \

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eux
+
+source "${OPS_ROOT}"/helpers/snap-logger.sh "hook-post-refresh"
+
+backup_opensearch_home() {
+    local target="${SNAP_DATA}/opensearch_home_backup"
+    rm -rf "${target}"
+    mkdir -p "${target}"
+    cp -r "${OPENSEARCH_HOME}/." "${target}/"
+}
+
+replace_stale_jars() {
+    declare -a common=(modules plugins lib)
+    for dir in "${common[@]}"; do
+        find "${OPENSEARCH_HOME}/${dir}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+        cp -r "${SNAP}/usr/share/opensearch/${dir}/"* \
+            "${OPENSEARCH_HOME}/${dir}/"
+    done
+}
+
+change_owner() {
+    local owner="$1"
+    declare -a folders=("${SNAP_DATA}")
+    for f in "${folders[@]}"; do
+        chown -R "${owner}" "${f}/"*
+        chgrp root "${f}/"*
+    done
+}
+
+change_owner root
+backup_opensearch_home
+replace_stale_jars
+change_owner snap_daemon

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -4,32 +4,35 @@ set -eux
 
 source "${OPS_ROOT}"/helpers/snap-logger.sh "hook-post-refresh"
 
-backup_opensearch_home() {
-    local target="${SNAP_DATA}/opensearch_home_backup"
-    rm -rf "${target}"
-    mkdir -p "${target}"
-    cp -r "${OPENSEARCH_HOME}/." "${target}/"
+set_previous_revision() {
+    for candidate in "${SNAP_DATA}"/../*; do
+        revision=$(basename "${candidate}")
+
+        # skip 'common', 'current' and current revision
+        [[ "${revision}" == "common" ]] && continue
+        [[ "${revision}" == "current" ]] && continue
+        [[ "${revision}" == "${SNAP_REVISION}" ]] && continue
+
+        revision_opensearch_home="${candidate}/usr/share/opensearch"
+
+        [[ -d "${revision_opensearch_home}" ]] || continue
+        if diff -qr "${OPENSEARCH_HOME}" "$revision_opensearch_home" >/dev/null 2>&1; then
+            snapctl set last-revision=${revision}
+            return 0
+        fi
+    done
 }
 
 replace_stale_jars() {
     declare -a common=(modules plugins lib)
     for dir in "${common[@]}"; do
-        find "${OPENSEARCH_HOME}/${dir}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-        cp -r "${SNAP}/usr/share/opensearch/${dir}/"* \
-            "${OPENSEARCH_HOME}/${dir}/"
+        "${SNAP}"/usr/bin/rsync -a --delete "${SNAP}/usr/share/opensearch/${dir}/" "${OPENSEARCH_HOME}/${dir}/"
     done
 }
 
-change_owner() {
-    local owner="$1"
-    declare -a folders=("${SNAP_DATA}")
-    for f in "${folders[@]}"; do
-        chown -R "${owner}" "${f}/"*
-        chgrp root "${f}/"*
-    done
-}
-
-change_owner root
-backup_opensearch_home
-replace_stale_jars
-change_owner snap_daemon
+set_previous_revision
+setpriv \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid snap_daemon -- \
+    bash -c "$(declare -f replace_stale_jars); replace_stale_jars"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -7,12 +7,14 @@ source "${OPS_ROOT}"/helpers/snap-logger.sh "hook-post-refresh"
 replace_stale_jars() {
     declare -a common=(modules plugins lib)
     for dir in "${common[@]}"; do
-        "${SNAP}"/usr/bin/rsync -a --delete "${SNAP}/usr/share/opensearch/${dir}/" "${OPENSEARCH_HOME}/${dir}/"
+        setpriv \
+            --clear-groups \
+            --reuid snap_daemon \
+            --regid snap_daemon -- \
+            "${SNAP}/usr/bin/rsync" -a --delete \
+            "${SNAP}/usr/share/opensearch/${dir}/" \
+            "${OPENSEARCH_HOME}/${dir}/"
     done
 }
 
-setpriv \
-    --clear-groups \
-    --reuid snap_daemon \
-    --regid snap_daemon -- \
-    bash -c "$(declare -f replace_stale_jars); replace_stale_jars"
+replace_stale_jars

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -6,7 +6,7 @@ source "${OPS_ROOT}/helpers/snap-logger.sh" "hook-pre-refresh"
 restore_previous_home_if_present() {
     # set last_revision as most recently modified dir in $SNAP/..
     last_revision=$(
-        find "${SNAP}"/.. \
+        find "${SNAP_DATA}"/.. \
             -mindepth 1 -maxdepth 1 \
             -type d \
             ! -name current \

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -4,22 +4,17 @@ set -eux
 source "${OPS_ROOT}/helpers/snap-logger.sh" "hook-pre-refresh"
 
 restore_previous_home_if_present() {
-    local backup="${SNAP_DATA}/opensearch_home_backup"
-    [ -d "${backup}" ] || return 0
+    last_revision=$(snapctl get last-revision)
+    local prev_opensearch_home="${SNAP_DATA}/../${last_revision}/usr/share/opensearch"
+    [ -d "${prev_opensearch_home}" ] || return 0
 
-    rm -rf ${OPENSEARCH_HOME}
-    mkdir -p "${OPENSEARCH_HOME}"
-    cp -r "${backup}/." "${OPENSEARCH_HOME}/"
+    "${SNAP}"/usr/bin/rsync -a --delete "${prev_opensearch_home}/" "${OPENSEARCH_HOME}/"
 }
 
-change_owner() {
-    local owner="$1"
-    declare -a folders=("${SNAP_DATA}")
-    for f in "${folders[@]}"; do
-        chown -R "${owner}" "${f}/"*
-        chgrp root "${f}/"*
-    done
-}
-change_owner root
-restore_previous_home_if_present
-change_owner snap_daemon
+setpriv \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid snap_daemon -- \
+    bash -c "$(declare -f restore_previous_home_if_present); restore_previous_home_if_present"
+
+snapctl unset last-revision

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -21,11 +21,12 @@ restore_previous_home_if_present() {
     local prev_opensearch_home="${SNAP_DATA}/../${last_revision}/usr/share/opensearch"
     [ -d "${prev_opensearch_home}" ] || return 0
 
-    "${SNAP}"/usr/bin/rsync -a --delete "${prev_opensearch_home}/" "${OPENSEARCH_HOME}/"
+    setpriv \
+        --clear-groups \
+        --reuid snap_daemon \
+        --regid snap_daemon -- \
+        "${SNAP}"/usr/bin/rsync -a --delete \
+        "${prev_opensearch_home}/" "${OPENSEARCH_HOME}/"
 }
 
-setpriv \
-    --clear-groups \
-    --reuid snap_daemon \
-    --regid snap_daemon -- \
-    bash -c "$(declare -f restore_previous_home_if_present); restore_previous_home_if_present"
+restore_previous_home_if_present

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -10,6 +10,7 @@ restore_previous_home_if_present() {
             -mindepth 1 -maxdepth 1 \
             -type d \
             ! -name current \
+            ! -name common \
             ! -name "$SNAP_REVISION" \
             -printf '%T@ %P\n' |
             sort -nr |

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -4,7 +4,7 @@ set -eux
 source "${OPS_ROOT}/helpers/snap-logger.sh" "hook-pre-refresh"
 
 restore_previous_home_if_present() {
-    # set last_revision as most recently modified dir in $SNAP
+    # set last_revision as most recently modified dir in $SNAP/..
     last_revision=$(
         find "${SNAP}"/.. \
             -mindepth 1 -maxdepth 1 \

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eux
+
+source "${OPS_ROOT}/helpers/snap-logger.sh" "hook-pre-refresh"
+
+restore_previous_home_if_present() {
+    local backup="${SNAP_DATA}/opensearch_home_backup"
+    [ -d "${backup}" ] || return 0
+
+    rm -rf ${OPENSEARCH_HOME}
+    mkdir -p "${OPENSEARCH_HOME}"
+    cp -r "${backup}/." "${OPENSEARCH_HOME}/"
+}
+
+change_owner() {
+    local owner="$1"
+    declare -a folders=("${SNAP_DATA}")
+    for f in "${folders[@]}"; do
+        chown -R "${owner}" "${f}/"*
+        chgrp root "${f}/"*
+    done
+}
+change_owner root
+restore_previous_home_if_present
+change_owner snap_daemon

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -4,7 +4,19 @@ set -eux
 source "${OPS_ROOT}/helpers/snap-logger.sh" "hook-pre-refresh"
 
 restore_previous_home_if_present() {
-    last_revision=$(snapctl get last-revision)
+    # set last_revision as most recently modified dir in $SNAP
+    last_revision=$(
+        find "${SNAP}"/.. \
+            -mindepth 1 -maxdepth 1 \
+            -type d \
+            ! -name current \
+            ! -name "$SNAP_REVISION" \
+            -printf '%T@ %P\n' |
+            sort -nr |
+            head -n1 |
+            awk '{print $2}'
+    )
+
     local prev_opensearch_home="${SNAP_DATA}/../${last_revision}/usr/share/opensearch"
     [ -d "${prev_opensearch_home}" ] || return 0
 
@@ -16,5 +28,3 @@ setpriv \
     --reuid snap_daemon \
     --regid snap_daemon -- \
     bash -c "$(declare -f restore_previous_home_if_present); restore_previous_home_if_present"
-
-snapctl unset last-revision

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -251,6 +251,7 @@ parts:
       - zlib1g
       - libqatzip3
       - acl
+      - rsync
 
 
   wrapper-scripts:


### PR DESCRIPTION
The snap copies over JAR files to `$OPENSEARCH_HOME` during the install hook. This hook is not executed on a snap refresh, which is what the charm uses during upgrades. This results in the upgraded charm using stale jars and running the previously installed version of OpenSearch.

This PR:
- adds a post-refresh hook to overwrite stale jars in `$OPENSEARCH_HOME`
- adds a pre-refresh hook to overwrite `$OPENSEARCH_HOME` with the jars from the most recent revision previously installed

The pre-refresh hook is specifically for roll backs to the most recently installed revision. If a snap user refreshes to a revision other than the most recently installed one, the jars will not be the expected ones