### PR TITLE
patch: Add plugs to opensearch.node binary

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,6 +188,11 @@ apps:
     plugs:
       - network
       - network-bind
+      - process-control
+      - system-observe
+      - sys-fs-cgroup-service
+      - mount-observe
+      - hardware-observe
     environment:
       bin_script: opensearch-node
 


### PR DESCRIPTION
This Pull Request add required snap interfaces to the `opensearch.node` snap application. The `opensearch.node` is used in rollback to override data state in disk to unblock a rollback since opensearch don't support rollbacks. Without these permissions AppArmor will block the tool. 