### PR TITLE
patch: Add snap common to list to change owner and group

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -74,7 +74,7 @@ set_base_config_props
 set_prometheus_exporter_config_props
 create_editable_cacerts_trust_store
 
-declare -a folders=("${SNAP_DATA}", "${SNAP_COMMON}")
+declare -a folders=("${SNAP_DATA}" "${SNAP_COMMON}")
 for f in "${folders[@]}"; do
     chown -R snap_daemon "${f}/"*
     chgrp -R root "${f}/"*

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -74,8 +74,7 @@ set_base_config_props
 set_prometheus_exporter_config_props
 create_editable_cacerts_trust_store
 
-#  "${SNAP_COMMON}"
-declare -a folders=("${SNAP_DATA}")
+declare -a folders=("${SNAP_DATA}", "${SNAP_COMMON}")
 for f in "${folders[@]}"; do
     chown -R snap_daemon "${f}/"*
     chgrp -R root "${f}/"*


### PR DESCRIPTION
This Pull request updates the install hook to change the ownership of `$SNAP_COMMON` so that the snap folders can be accessed by `snap_daemon`. This is needed by the snap to start since it uses `setpriv snap_daemon` to start. 

The changes were not needed before since the charm didn't include `logs` as a storage to be attached. 